### PR TITLE
Labs detail

### DIFF
--- a/archetypes/projekt.md
+++ b/archetypes/projekt.md
@@ -1,9 +1,9 @@
 ---
 layout: project #do not change
-lab: OK Lab Berlin #change into your city/lab
+lab: [berlin] #change into your city/lab
 imgname: #add file to assets/projects/your city
 title: Titel #project title
-status: Laufend 
+status: Laufend
 type: DRL
 draft: true #set to 'false'
 
@@ -16,4 +16,3 @@ links:
 
 ---
 <!--short project description here-->
-

--- a/content/labs/berlin.md
+++ b/content/labs/berlin.md
@@ -1,7 +1,6 @@
 ---
 city: Berlin
 title: OK Lab Berlin
-lab: OK Lab Berlin
 
 lat: 52.498493
 long: 13.381215
@@ -10,180 +9,180 @@ markerposition: right
 members:
 
 - name: Julia Kloiber
-  username-twitter: j_kloiber
+  username_twitter: j_kloiber
 
 - name: Stefan Wehrmeyer
-  username-github: stefanw
-  username-twitter: stefanwehrmeyer
+  username_github: stefanw
+  username_twitter: stefanwehrmeyer
 
 - name: Lucas Jacob
-  username-github: LucasJ
+  username_github: LucasJ
 
 - name: Magdalena Noffke
-  username-github: MagdaN
-  username-twitter: MagdalenaNoffke
+  username_github: MagdaN
+  username_twitter: MagdalenaNoffke
 
 - name: Friedrich Lindenberg
-  username-github: pudo
+  username_github: pudo
 
 - name: Fiona Krakenbürger
-  username-github: arduina
-  username-twitter: arduina
+  username_github: arduina
+  username_twitter: arduina
 
 - name: Sebastian Mondial
-  username-twitter: kappuchino
+  username_twitter: kappuchino
 
 - name: Christian Pape
-  username-twitter: chrpape
+  username_twitter: chrpape
 
 - name: Knud Möller
-  username-github: knudmoeller
-  username-twitter: knudmoeller
+  username_github: knudmoeller
+  username_twitter: knudmoeller
 
 - name: Knut Hühne
-  username-github: k-nut
+  username_github: k-nut
 
 - name: Jochen Klar
-  username-github: jochenklar
-  username-twitter: jochenklar
+  username_github: jochenklar
+  username_twitter: jochenklar
 
 - name: Thomas Schmidt
-  username-github: netAction
+  username_github: netAction
   sername-twitter: netAction
 
 - name: Moritz Klack
-  username-github: moklick
-  username-twitter: moklick
+  username_github: moklick
+  username_twitter: moklick
 
 - name: Daniel Dietrich
-  username-github: ddie
-  username-twitter: ddie
+  username_github: ddie
+  username_twitter: ddie
 
 - name: Christopher Möller
-  username-github: chrtze
+  username_github: chrtze
 
 - name: Andy Lindemann
-  username-github: AndyTheGiant
-  username-twitter: andymensional
+  username_github: AndyTheGiant
+  username_twitter: andymensional
 
 - name: Friedrich Schuman
 
 - name: Michael Hörz
-  username-github: m-hoerz
-  username-twitter: data_meining
+  username_github: m-hoerz
+  username_twitter: data_meining
 
 - name: Niklas Riekenbrauck
-  username-github: nikriek
-  username-twitter: nikriek
+  username_github: nikriek
+  username_twitter: nikriek
 
 - name: Thomas Tursics
-  username-github: tursics
-  username-twitter: tursics
+  username_github: tursics
+  username_twitter: tursics
 
 - name: Stefan Heil
-  username-twitter: Pol_Hackonomist
+  username_twitter: Pol_Hackonomist
 
 - name: Dirk Schumacher
-  username-github: dirkschumacher
-  username-twitter: dirk_sch
+  username_github: dirkschumacher
+  username_twitter: dirk_sch
 
 - name: Daniel Mack
-  username-github: zonque
-  username-twitter: zonque
+  username_github: zonque
+  username_twitter: zonque
 
 - name: Udo Kramer
-  username-github: optikfluffel
-  username-twitter: optikfluffel
+  username_github: optikfluffel
+  username_twitter: optikfluffel
 
 - name: Simon Jockers
-  username-github: sjockers
-  username-twitter: sjockers
+  username_github: sjockers
+  username_twitter: sjockers
 
 - name: Christian Rijke
-  username-github: cnrk
-  username-twitter: crijke
+  username_github: cnrk
+  username_twitter: crijke
 
 - name: Ulrike Thalheim
 
 - name: Stefan Graupner
-  username-github: eFrane
-  username-twitter: eFrane
+  username_github: eFrane
+  username_twitter: eFrane
 
 - name: Giuseppe Di Vincenzo
-  username-github: g-div
+  username_github: g-div
 
 - name: Adrian Partl
-  username-github: adrpar
-  username-twitter: AdrianPartl
+  username_github: adrpar
+  username_twitter: AdrianPartl
 
 - name: Christine Pautsch
-  username-github: jabka
-  username-twitter: jabka
+  username_github: jabka
+  username_twitter: jabka
 
 - name: André Rebentisch
-  username-github: agonarch
-  username-twitter: agonarch
+  username_github: agonarch
+  username_twitter: agonarch
 
 - name: Claus Höfele
-  username-github: choefele
-  username-twitter: claushoefele
+  username_github: choefele
+  username_twitter: claushoefele
 
 - name: Roland Möws
 
 - name: Mario Behling
-  username-github: mariobehling
-  username-twitter: mariobehling
+  username_github: mariobehling
+  username_twitter: mariobehling
 
 - name: Tobias Kräntzer
-  username-github: anagromataf
-  username-twitter: anagrom_ataf
+  username_github: anagromataf
+  username_twitter: anagrom_ataf
 
 - name: Holger Drewes
-  username-github: holgerd77
-  username-twitter: HolgerD77
+  username_github: holgerd77
+  username_twitter: HolgerD77
 
 - name: Tobias Preuss
-  username-github: johnjohndoe
-  username-twitter: tbsprs
+  username_github: johnjohndoe
+  username_twitter: tbsprs
 
 - name: Christoph Lauer
-  username-github: notapirate
+  username_github: notapirate
 
 - name: Marc Kastner
-  username-github: happy-koala
-  username-twitter: marc_kastner
+  username_github: happy-koala
+  username_twitter: marc_kastner
 
 - name: Alex Corbi
-  username-github: acorbi
-  username-twitter: acorbi
+  username_github: acorbi
+  username_twitter: acorbi
 
 - name: Elf Pavlik
-  username-github: elf-pavlik
-  username-twitter: elfpavlik
+  username_github: elf-pavlik
+  username_twitter: elfpavlik
 
 - name: Jon Richter
-  username-github: almereyda
-  username-twitter: almereyda
+  username_github: almereyda
+  username_twitter: almereyda
 
 - name: Hans-Helge Bürger
-  username-github: obstschale
-  username-twitter: obstschale
+  username_github: obstschale
+  username_twitter: obstschale
 
 - name: Katharina Albers
-  username-github: fuzzylogic2000
-  username-twitter: fuzzylogic2020
+  username_github: fuzzylogic2000
+  username_twitter: fuzzylogic2020
 
 - name: Zhuo-Fei Hui
-  username-github: zfhui
-  username-twitter: zfhui
+  username_github: zfhui
+  username_twitter: zfhui
 
 - name: Jannis Redmann
-  username-github: derhuerst
-  username-twitter: derhuerst
+  username_github: derhuerst
+  username_twitter: derhuerst
 
 - name: Julius Tens
-  username-github: juliuste
-  username-twitter: juliustens
+  username_github: juliuste
+  username_twitter: juliustens
 
 
 links:
@@ -199,3 +198,5 @@ leads:
 - name: E-Mail
   url: mailto:berlin@codefor.de
 ---
+
+Willkommen beim Berliner OK Lab! Wir sind etwa 30 Leute und arbeiten in verschiedenen Gruppen an Projekten rund um Open Data und Civic Tech. Wir kommen aus ganz verschiedenen Bereichen, entsprechend behandeln auch die Projekte an denen wir arbeiten ganz unterschiedliche Themen.

--- a/content/labs/bonn.md
+++ b/content/labs/bonn.md
@@ -1,7 +1,6 @@
 ---
 city: Bonn
 title: OK Lab Bonn-Rhein-Sieg
-lab: OK Lab Bonn-Rhein-Sieg
 lat: 50.7371974
 long: 7.0947157
 markerposition: right
@@ -9,38 +8,38 @@ markerposition: right
 members:
 
 - name: Sven Hense
-  username-github: opendatabonn
-  username-twitter: eGovBonn
+  username_github: opendatabonn
+  username_twitter: eGovBonn
 
 - name: Sascha Foerster
-  username-github: saschafoerster
-  username-twitter: Sascha_Foerster
+  username_github: saschafoerster
+  username_twitter: Sascha_Foerster
 
 - name: Andreas Job
-  username-twitter: AndreasJob
+  username_twitter: AndreasJob
 
 - name: Jens Schaller
-  username-github: SchallerJe
-  username-twitter: schallerje
+  username_github: SchallerJe
+  username_twitter: schallerje
 
 - name: Josef Schugt
-  username-twitter: penpendede
+  username_twitter: penpendede
 
 - name: Damian Paderta
-  username-github: daimpad
-  username-twitter: paderta
+  username_github: daimpad
+  username_twitter: paderta
 
 - name: Martin Schneider
-  username-github: schneyra
-  username-twitter: schneyra
+  username_github: schneyra
+  username_twitter: schneyra
 
 - name: Stephan Lentzen
-  username-github: inazr
-  username-twitter: wipokar
+  username_github: inazr
+  username_twitter: wipokar
 
 - name: Michael Rolfsen
-  username-github: mrolfsen
-  username-twitter: michaelsupdates
+  username_github: mrolfsen
+  username_twitter: michaelsupdates
 
 links:
 

--- a/content/labs/chemnitz.md
+++ b/content/labs/chemnitz.md
@@ -1,7 +1,6 @@
 ---
 city: Chemnitz
 title: OK Lab Chemnitz
-lab: OK Lab Chemnitz
 lat: 50.83063
 long: 12.93973
 markerposition: right
@@ -9,16 +8,16 @@ markerposition: right
 members:
 
 - name: Morris Jobke
-  username-twitter: MorrisJbk
-  username-github: MorrisJobke
+  username_twitter: MorrisJbk
+  username_github: MorrisJobke
 - name: Tobias Gall
-  username-twitter: symptog
-  username-github: symptog
+  username_twitter: symptog
+  username_github: symptog
 - name: Ronny Hartenstein
-  username-twitter: rhflow_de
-  username-github: ronnyhartenstein
+  username_twitter: rhflow_de
+  username_github: ronnyhartenstein
 - name: Benedikt Geißler
-  username-github: benediktg5
+  username_github: benediktg5
 
 links:
 - name: Webseite

--- a/content/labs/dresden.md
+++ b/content/labs/dresden.md
@@ -1,7 +1,6 @@
 ---
 city: Dresden
 title: Open Data Dresden
-lab: OK Lab Dresden
 lat: 51.08113
 long: 13.72858
 
@@ -9,24 +8,24 @@ members:
 
 - name: Astro
   url: http://spaceboyz.net/~astro/
-  username-github: astro
-  username-twitter: astro1138
+  username_github: astro
+  username_twitter: astro1138
 - name: Consti
-  username-github: ubahnverleih
-  username-twitter: ubahnverleih
+  username_github: ubahnverleih
+  username_twitter: ubahnverleih
 - name: Rob
   url: http://boogiedev.net
-  username-github: robtranquillo
-  username-twitter: robtranquillo
+  username_github: robtranquillo
+  username_twitter: robtranquillo
 - name: jklmnn
-  username-github: jklmnn
-  username-twitter: JK70523
+  username_github: jklmnn
+  username_twitter: JK70523
 - name: Paul
-  username-github: balzer82
-  username-twitter: balzer82
+  username_github: balzer82
+  username_twitter: balzer82
 - name: kiliankoe
-  username-github: kiliankoe
-  username-twitter: kiliankoe
+  username_github: kiliankoe
+  username_twitter: kiliankoe
 - name: und wechselnd viele weitere Menschen
 
 

--- a/content/labs/duesseldorf.md
+++ b/content/labs/duesseldorf.md
@@ -1,7 +1,6 @@
 ---
 city: Düsseldorf
 title: OK Lab Düsseldorf
-lab: OK Lab Düsseldorf
 lat: 51.209478
 long: 6.7784333
 markerposition: left
@@ -35,46 +34,46 @@ leads:
 
 members:
 - name: Agnes Mainka
-  username-twitter: agnieszka_m
+  username_twitter: agnieszka_m
 - name: Alice Wiegand
-  username-twitter: lyzzy
+  username_twitter: lyzzy
 - name: Antje Feil
-  username-twitter: antjefeil
+  username_twitter: antjefeil
 - name: Arne Lieb
-  username-twitter: arnelieb
+  username_twitter: arnelieb
 - name: Catrin Boss
 - name: Christina Rentmeister
-  username-twitter: chrire
+  username_twitter: chrire
 - name: Dirk Nagels
-  username-twitter: OpenDirk
+  username_twitter: OpenDirk
 - name: Dr. Christian Knebel
-  username-github: cknebel
-  username-twitter: cknebel79
+  username_github: cknebel
+  username_twitter: cknebel79
 - name: Khalid Karroumi
 - name: Lara Knebel
-  username-twitter: lknebel19
+  username_twitter: lknebel19
 - name: Marcus Weiner
-  username-github: mraerino
-  username-twitter: mraerino
+  username_github: mraerino
+  username_twitter: mraerino
 - name: Max Schorradt
-  username-github: mechtecs
-  username-twitter: mechtecify
+  username_github: mechtecs
+  username_twitter: mechtecify
 - name: Oliver Vaupel
-  username-twitter: ovau
+  username_twitter: ovau
 - name: Patrick Schiffer
-  username-github: patrickschiffer
-  username-twitter: pschiffer
+  username_github: patrickschiffer
+  username_twitter: pschiffer
 - name: Phil Ninh
-  username-github: PhilNinh
-  username-twitter: philninh
+  username_github: PhilNinh
+  username_twitter: philninh
 - name: Sabine Manz
-  username-twitter: SabineManz
+  username_twitter: SabineManz
 - name: Stefan Müller
-  username-github: stefdus
-  username-twitter: stefdus
+  username_github: stefdus
+  username_twitter: stefdus
 - name: Steffen Pramel
 - name: Tobias Hübner
-  username-twitter: medienistik
+  username_twitter: medienistik
 - name: Tobias Siebenlist
-  username-twitter: t7l
+  username_twitter: t7l
 ---

--- a/content/labs/frankfurt.md
+++ b/content/labs/frankfurt.md
@@ -1,7 +1,6 @@
 ---
 city: Frankfurt
 title: OK Lab Frankfurt
-lab: OK Lab Frankfurt
 lat: 50.1167
 long: 8.6833
 markerposition: right
@@ -9,12 +8,12 @@ markerposition: right
 members:
 
 - name: Mischa Zöller
-  username-github: zoeller
-  username-twitter: zoellerm
+  username_github: zoeller
+  username_twitter: zoellerm
 
 - name: Bogomir Engel
-  username-github: aCandidMind
-  username-twitter: aCandidMind
+  username_github: aCandidMind
+  username_twitter: aCandidMind
 
 links:
 

--- a/content/labs/freiburg.md
+++ b/content/labs/freiburg.md
@@ -7,8 +7,8 @@ markerposition: right
 members:
 
 - name: Andreas Pawelke
-  username-github: Idna12
-  username-twitter: pa_wela
+  username_github: Idna12
+  username_twitter: pa_wela
 
 links:
 

--- a/content/labs/giessen.md
+++ b/content/labs/giessen.md
@@ -1,7 +1,6 @@
 ---
 city: Giessen
 title: OK Lab Gießen
-lab: OK Lab Gießen
 lat: 50.587142
 long: 8.690926
 markerposition: left
@@ -10,35 +9,35 @@ showsignup: false
 
 members:
 - name: Jan Ameli
-  username-github: jpameli
+  username_github: jpameli
 
 - name: Christian Schulze
-  username-github: ChristianSch
+  username_github: ChristianSch
 
 - name: Christian Oechler
-  username-github: COechler
+  username_github: COechler
 
 - name: Tobias Schwalm
-  username-github: tobiasschwalm
+  username_github: tobiasschwalm
 
 - name: Christian Heigele
-  username-github: cheigele
+  username_github: cheigele
 
 - name: Prof. Dr. Martin Przewloka
 
 - name: Marco Schäfer
-  username-github: msfr
+  username_github: msfr
 
 - name: Katharina Dort
 
 - name: Julian Schmitt
-  username-github: juschmitt
+  username_github: juschmitt
 
 - name: Florian Kolb
-  username-github: toxic2302
+  username_github: toxic2302
 
 - name: Vincent Elliott Wagner
-  username-github: serofax
+  username_github: serofax
 
 links:
 - name: Meetup

--- a/content/labs/hamburg.md
+++ b/content/labs/hamburg.md
@@ -1,7 +1,6 @@
 ---
 city: Hamburg
 title: OK Lab Hamburg
-lab: OK Lab Hamburg
 lat: 53.5476165
 long: 9.9800385
 
@@ -12,52 +11,52 @@ markerposition: right
 members:
 
 - name: Timo lundelius
-  username-github: lundelius
-  username-twitter: timo_lundelius
+  username_github: lundelius
+  username_twitter: timo_lundelius
 
 - name: Philipp Geisler
-  username-github: philippgeisler
-  username-twitter: zelpst
+  username_github: philippgeisler
+  username_twitter: zelpst
 
 - name: Solveig Schröder
-  username-github: solveigs
-  username-twitter: SolveigSchroder
+  username_github: solveigs
+  username_twitter: SolveigSchroder
 
 - name: Hannes
-  username-github: kannes
-  username-twitter: cartocalypse
+  username_github: kannes
+  username_twitter: cartocalypse
 
 - name: Achim Tack
-  username-github: ATack
-  username-twitter: A_Tack
+  username_github: ATack
+  username_twitter: A_Tack
 
 - name: Marco Maas
-  username-github: marcomaas
-  username-twitter: themaastrix
+  username_github: marcomaas
+  username_twitter: themaastrix
 
 - name: Timo Kessler
-  username-github: tike
-  username-twitter: tike10
+  username_github: tike
+  username_twitter: tike10
 
 - name: Patrick Stotz
-  username-github: PatrickStotz
-  username-twitter: PatrickStotz
+  username_github: PatrickStotz
+  username_twitter: PatrickStotz
 
 - name: Lukasz Plotnicki
-  username-github: lplotni
-  username-twitter: lplotni
+  username_github: lplotni
+  username_twitter: lplotni
 
 - name: Aurelius Wendelken
-  username-github: webtobesocial
-  username-twitter: webtobesocial
+  username_github: webtobesocial
+  username_twitter: webtobesocial
 
 - name: Andreas Wienes
-  username-github: andreas-wienes
-  username-twitter: AndreasWienes
+  username_github: andreas-wienes
+  username_twitter: AndreasWienes
 
 - name: Felix Kruse
-  username-github: felixkqb
-  username-twitter: felixkqb
+  username_github: felixkqb
+  username_twitter: felixkqb
 
 - name: Anne Kis
 

--- a/content/labs/hannover.md
+++ b/content/labs/hannover.md
@@ -9,35 +9,35 @@ markerposition: left
 members:
 
 #- name: Sven Pfennig
-#  username-github: 0xE282B0
-#  username-twitter: NicolajKirchhof
+#  username_github: 0xE282B0
+#  username_twitter: NicolajKirchhof
 
 - name: Holger Biermann
-  username-github: qompa
-  username-twitter: qompacom
+  username_github: qompa
+  username_twitter: qompacom
 
 - name: Jan Sauer
-  username-github: jansauer
-  username-twitter: jansauer
+  username_github: jansauer
+  username_twitter: jansauer
 
 - name: Nikolaus Pohle
-  username-github: npohle
-  username-twitter: npohle
+  username_github: npohle
+  username_twitter: npohle
 
 - name: Nicolaj Kirchhof
-  username-github: nicolajkirchhof
-  username-twitter: nicolajkirchhof
+  username_github: nicolajkirchhof
+  username_twitter: nicolajkirchhof
 
 - name: Björn Vofrei
-  username-github: typedance
-  username-twitter: typedance
+  username_github: typedance
+  username_twitter: typedance
 
 - name: Anna Kasprzik
-  username-github: annakasprzik
+  username_github: annakasprzik
 
 - name: Christoph Banke
-  username-github: christophbanke
-  username-twitter: christophbanke
+  username_github: christophbanke
+  username_twitter: christophbanke
 
 links:
 - name: Slack

--- a/content/labs/heidelberg.md
+++ b/content/labs/heidelberg.md
@@ -8,10 +8,10 @@ markerposition: left
 
 members:
 - name: Jasper Schmidt
-  username-github:
-  username-twitter:
+  username_github:
+  username_twitter:
 - name: Mandy Reinhardt
-  username-github: mandyr
+  username_github: mandyr
 
 links:
 - name: Meetup

--- a/content/labs/heilbronn.md
+++ b/content/labs/heilbronn.md
@@ -1,34 +1,33 @@
 ---
 city: Heilbronn
 title: Code for Heilbronn
-lab: OK Lab Heilbronn
 lat: 49.139059
 long: 9.220404
 markerposition: right
 
 members:
 - name: Adrian Stabiszewski
-  username-github: grundid
-  username-twitter: nitegate
+  username_github: grundid
+  username_twitter: nitegate
 - name: Jonathan Günz
-  username-github: harmoniemand
-  username-twitter: harmoniemand
+  username_github: harmoniemand
+  username_twitter: harmoniemand
 - name: Leandro
-  username-twitter: _LeoDJ
+  username_twitter: _LeoDJ
 - name: Franz Imschweiler
 - name: Steffen Jung
-  username-github: gravima
+  username_github: gravima
 - name: Felix Ebert
-  username-github: felixebert
-  username-twitter: femeb
+  username_github: felixebert
+  username_twitter: femeb
 - name: Valentin Fischer
-  username-twitter: TheVale98
+  username_twitter: TheVale98
 - name: Joas Schilling
-  username-twitter: nickvergessen
+  username_twitter: nickvergessen
 - name: Lukas Himsel
-  username-github: lukas-h
+  username_github: lukas-h
 - name: Patrick Hahn
-  username-twitter: patrick24651
+  username_twitter: patrick24651
 
 links:
 - name: Meetup

--- a/content/labs/jena.md
+++ b/content/labs/jena.md
@@ -1,7 +1,6 @@
 ---
 city: Jena
 title: OK Lab Jena
-lab: OK Lab Jena
 lat: 50.9223394
 long: 11.5762312
 markerposition: left
@@ -9,15 +8,15 @@ markerposition: left
 members:
 
 - name: Achim
-  username-github: ahzf
-  username-twitter: ahzf
+  username_github: ahzf
+  username_twitter: ahzf
 - name: Andreas
-  username-twitter: nunAmen
+  username_twitter: nunAmen
 - name: Melanie
 - name: Mirko
-  username-twitter: fnchh
+  username_twitter: fnchh
 - name: Robert
-  username-twitter: p1ng0ut
+  username_twitter: p1ng0ut
 - name: Richardo
 
 links:

--- a/content/labs/karlsruhe.md
+++ b/content/labs/karlsruhe.md
@@ -1,7 +1,6 @@
 ---
 city: Karlsruhe
 title: OK Lab Karlsruhe
-lab: OK Lab Karlsruhe
 lat: 49.013397
 long: 8.404370
 markerposition: left

--- a/content/labs/koeln.md
+++ b/content/labs/koeln.md
@@ -1,7 +1,6 @@
 ---
 city: Köln
 title: OK Lab Köln
-lab: OK Lab Köln
 lat: 50.9554784
 long: 6.9104529
 markerposition: left
@@ -10,56 +9,56 @@ projectsorder: reverse
 members:
 
 - name: Marian Steinbach
-  username-github: marians
-  username-twitter: MarianSteinbach
+  username_github: marians
+  username_twitter: MarianSteinbach
 
 - name: Marcel Belledin
-  username-github: marcel12bell
-  username-twitter: MarcelBelledin
+  username_github: marcel12bell
+  username_twitter: MarcelBelledin
 
 - name: Patricia Ennenbach
-  username-github: P3nny
-  username-twitter: pen1710
+  username_github: P3nny
+  username_twitter: pen1710
 
 - name: Ingrid Bluoss
-  username-github: datenvisualisierung
+  username_github: datenvisualisierung
 
 - name: Matthias
-  username-github: Matthias Krauss
+  username_github: Matthias Krauss
 
 - name: Tim Becker
-  username-github: a2800276
+  username_github: a2800276
 
 - name: Thomas Liebig
-  username-github: thomasliebig
+  username_github: thomasliebig
 
 - name: Rene Drexler
-  username-github: nifix777
+  username_github: nifix777
 
 - name: Alex Brand
-  username-github: alinx
+  username_github: alinx
 
 - name: Wolfram Eberius
-  username-github: weberius
-  username-twitter: eberius
+  username_github: weberius
+  username_twitter: eberius
 
 - name: Horst Meyer
-  username-github: horald
+  username_github: horald
 
 - name: Patrick Maué
-  username-github: pajoma
+  username_github: pajoma
 
 - name: Karen Schwane
-  username-github: karen-sch
-  username-twitter: hi_i_am_karen
+  username_github: karen-sch
+  username_twitter: hi_i_am_karen
 
 - name: Peter Mayr
-  username-github: hatorikibble
-  username-twitter: hatorikibble
+  username_github: hatorikibble
+  username_twitter: hatorikibble
 
 - name: Christoph Finke
-  username-github: chfinke
-  username-twitter: chfinke
+  username_github: chfinke
+  username_twitter: chfinke
 
 links:
 - name: Meetup

--- a/content/labs/leipzig.md
+++ b/content/labs/leipzig.md
@@ -1,7 +1,6 @@
 ---
 city: Leipzig
 title: OK Lab Leipzig
-lab: OK Lab Leipzig
 lat: 51.3322131
 long: 12.3735576
 markerposition: right
@@ -12,47 +11,47 @@ markerposition: right
 members:
 
 - name: Markus Zapke-Gründemann
-  username-github: keimlink
-  username-twitter: keimlink
+  username_github: keimlink
+  username_twitter: keimlink
 - name: Thomas Kandler
-  username-github: tkan
-  username-twitter: geolibre
+  username_github: tkan
+  username_twitter: geolibre
 - name: Matthias Petzold
-  username-github: videomatze
+  username_github: videomatze
 - name: Olf
-  username-github: olf42
+  username_github: olf42
 - name: Max Brauer
-  username-github: debvortex
-  username-twitter: deb_vortex
+  username_github: debvortex
+  username_twitter: deb_vortex
 - name: Pascal Müller
-  username-github: paesku
-  username-twitter: paesku
+  username_github: paesku
+  username_twitter: paesku
 - name: Hans-Gert Gräbe
-  username-github: hg-graebe
+  username_github: hg-graebe
 - name: Marcello Ceschia
-  username-github: marcelloceschia
+  username_github: marcelloceschia
 - name: Ricardo Usbeck
-  username-github: RicardoUsbeck
+  username_github: RicardoUsbeck
 - name: Lars Wesemann
-  username-github: spinner0815
-  username-twitter: spinner0815
+  username_github: spinner0815
+  username_twitter: spinner0815
 - name: Lars Mai
-  username-github: lhm
+  username_github: lhm
 - name: Andreas Haller
-  username-github: ahx
+  username_github: ahx
 - name: Martin Feige
-  username-github: kater169
-  username-twitter: kater169
+  username_github: kater169
+  username_twitter: kater169
 - name: Eric Kelm
-  username-github: eric2501
+  username_github: eric2501
 - name: Manuel Stößel
-  username-github: ManuPogo
+  username_github: ManuPogo
 - name: Robert Schmidt
-  username-github: NucsuM
+  username_github: NucsuM
 - name: Sebastian Peters
-  username-github: sepe81
+  username_github: sepe81
 - name: Jörg Reichert
-  username-github: joergreichert
+  username_github: joergreichert
 
 links:
 - name: Meetup

--- a/content/labs/magdeburg.md
+++ b/content/labs/magdeburg.md
@@ -1,7 +1,6 @@
 ---
 city: Magdeburg
 title: OK Lab Magdeburg
-lab: OK Lab Magdeburg
 lat: 52.11946
 long: 11.62941
 markerposition: right
@@ -9,12 +8,12 @@ markerposition: right
 members:
 
 - name: Jens Winter
-  username-github: JensWinter
-  username-twitter: JensWinter
+  username_github: JensWinter
+  username_twitter: JensWinter
 
 - name: Anton Müller
-  username-github: TheRojam
-  username-twitter: TheRojam
+  username_github: TheRojam
+  username_twitter: TheRojam
 
 links:
 

--- a/content/labs/mecklenburg-vorpommern.md
+++ b/content/labs/mecklenburg-vorpommern.md
@@ -8,8 +8,8 @@ markerposition: right
 
 members:
 - name: Michael Milz
-  username-github: michamilz
-  username-twitter: micha_milz
+  username_github: michamilz
+  username_twitter: micha_milz
 
 links:
 - name: Mailingliste

--- a/content/labs/muenchen.md
+++ b/content/labs/muenchen.md
@@ -1,7 +1,6 @@
 ---
 city: München
 title: OK Lab München
-lab: OK Lab München
 lat: 48.14356
 long: 11.55792
 markerposition: right
@@ -31,38 +30,38 @@ markerposition: right
 members:
 
 - name: Matt Fullerton
-  username-github: mattfullerton
-  username-twitter: mattfullerton
+  username_github: mattfullerton
+  username_twitter: mattfullerton
 
 - name: Birgit Fullerton
-  username-github: birgitfullerton
-  username-twitter: bbfullerton
+  username_github: birgitfullerton
+  username_twitter: bbfullerton
 
 - name: Andreas Hubel
-  username-github: saerdnaer
-  username-twitter: saerdnaer
+  username_github: saerdnaer
+  username_twitter: saerdnaer
 
 - name: Mario Haim
-  username-github: MarHai
-  username-twitter: DrFollowMario
+  username_github: MarHai
+  username_twitter: DrFollowMario
 
 - name: Tobias Hößl
-  username-twitter: tobiasHoessl
-  username-github: catoth
+  username_twitter: tobiasHoessl
+  username_github: catoth
 
 - name: Maximillian Richt
-  username-twitter: robbi5
-  username-github: robbi5
+  username_twitter: robbi5
+  username_github: robbi5
 
 - name: Rob Ruidisch
 
 - name: Konstantin Schütze
-  username-twitter: konstinx
-  username-github: konstin
+  username_twitter: konstinx
+  username_github: konstin
 
 - name: Manuel Hartmann
-  username-twitter: bAck_mumu
-  username-github: bAckmumu
+  username_twitter: bAck_mumu
+  username_github: bAckmumu
 
 
 

--- a/content/labs/muenster.md
+++ b/content/labs/muenster.md
@@ -7,58 +7,66 @@ long: 7.630490
 members:
 
 - name: Gerald Pape
-  username-github: ubergesundheit
-  username-twitter: ubergesundheit
+  username_github: ubergesundheit
+  username_twitter: ubergesundheit
 
 - name: Tobias Bradtke
-  username-github: webwurst
+  username_github: webwurst
 
 - name: Yannic Schencking
-  username-github: jahnique
+  username_github: jahnique
 
 - name: Thomas Werner
-  username-github: tomsrocket
-  username-twitter: toms_rocket
+  username_github: tomsrocket
+  username_twitter: toms_rocket
 
 - name: Christian Römer
-  username-github: thunfischtoast
+  username_github: thunfischtoast
 
 - name: Thomas Terstiege
-  username-github: silberzwiebel
-  username-twitter: krtfflslt
+  username_github: silberzwiebel
+  username_twitter: krtfflslt
 
 links:
 - name: Webseite
   url: https://codeformuenster.org/
+  top: true
 
 - name: Twitter
   url: https://twitter.com/codeformuenster
+  top: true
 
 - name: Meetup
   url: https://meetup.com/OK-Lab-Munster/
+  top: true
 
 - name: Gettogether
   url: https://gettogether.community/code-for-m%C3%BCnster/
+  top: true
 
 - name: Open Data Day Zusammenfassung 2018
   url: https://codeformuenster.org/blog/2018/03/06/odd-2018/
+  top: false
 
 - name: Open Data Day Zusammenfassung 2017
   url: https://codeformuenster.org/blog/2017/03/07/odd-2017/
+  top: false
 
 - name: Jahresrückblick 2016
   url: https://codeformuenster.org/blog/2016/03/16/odd-rueckblick/
+  top: false
 
 - name: Jahresrückblick 2015
   url: https://codeformuenster.org/blog/2016/03/05/rueckblick-2015/
+  top: false
 
 leads:
-- name: Gerald Pape
-  url: mailto:muenster@codefor.de
-- name: Thomas Werner
-  url: mailto:muenster@codefor.de
-- name: Tobias Bradtke
-  url: mailto:muenster@codefor.de
-- name: Yannic Schencking
+- name: Kontakt
   url: mailto:muenster@codefor.de
 ---
+
+Als eines der eher technischen Labs dreht es sich bei uns vor allem eher darum, wie man eine solide und offene Basis für Open Data-Anwendungen aller Art herstellen kann.
+
+Bei unseren wöchentlichen offenen Treffen bieten wir allen Interessierten die Möglichkeit zum Erlernen verschiedenster IT-Kenntnisse und zum Umgang mit offenen Daten. Vor allem aber lernt man bei uns die eigenen Fähigkeiten mit viel Leidenschaft für einen guten Zweck einzusetzen.
+
+Ding dong Platzhalter usw

--- a/content/labs/niederrhein.md
+++ b/content/labs/niederrhein.md
@@ -9,31 +9,31 @@ showsignup: false
 
 members:
 - name: Timo Jeske
-  username-github: odadev
-  username-twitter: timojeske
+  username_github: odadev
+  username_twitter: timojeske
 - name: Claus Arndt
-  username-twitter: derarndt
+  username_twitter: derarndt
 - name: Elmar Burke
-  username-github: elmarburke
-  username-twitter: elmarburke
+  username_github: elmarburke
+  username_twitter: elmarburke
 - name: Alexander Schoog
-  username-github: nitrax95
-  username-twitter: ASchoog
+  username_github: nitrax95
+  username_twitter: ASchoog
 - name: Ulrich Greveler
-  username-github: greveler
-  username-twitter: greveler
+  username_github: greveler
+  username_twitter: greveler
 - name: Torsten Kannenberg
-  username-github: TorstenKa
-  username-twitter: torstenKa
+  username_github: TorstenKa
+  username_twitter: torstenKa
 - name: David Krystof
-  username-github: dakrys
-  username-twitter: Dakrys
+  username_github: dakrys
+  username_twitter: Dakrys
 - name: Manfred Schramm
-  username-github: Hhhhmmmmasch
-  username-twitter: hhhhmmmmasch
+  username_github: Hhhhmmmmasch
+  username_twitter: hhhhmmmmasch
 - name: Tobias Hahnen
-  username-github: thahnen
-  username-twitter: Hubblerone
+  username_github: thahnen
+  username_twitter: Hubblerone
 - name: Marcel Sowade
 - name: Martin Moutarde
 - name: Klaus Stalinski

--- a/content/labs/osnabrueck.md
+++ b/content/labs/osnabrueck.md
@@ -1,5 +1,5 @@
 ---
-city: Osnabrueck
+city: Osnabrück
 title: OK Lab Osnabrueck
 lab: OK Lab Osnabrueck
 lat: 52.2668370

--- a/content/labs/osnabrueck.md
+++ b/content/labs/osnabrueck.md
@@ -9,24 +9,24 @@ showsignup: false
 
 members:
 - name: Auss Abbood
-  username-github: https://github.com/aauss
-  # username-twitter:
+  username_github: https://github.com/aauss
+  # username_twitter:
 
 - name: John Berrora
-  username-github: https://github.com/johnberroa
-  # username-twitter:
+  username_github: https://github.com/johnberroa
+  # username_twitter:
 
 - name: Rüdiger Frederik Busche
-  username-github: https://github.com/JarnoRFB
-  # username-twitter:
+  username_github: https://github.com/JarnoRFB
+  # username_twitter:
 
 - name: Anton Laukemper
-  username-github: https://github.com/Zaitur
-  # username-twitter:
+  username_github: https://github.com/Zaitur
+  # username_twitter:
 
 - name: Jannik Steinmann
-  username-github: https://github.com/DerGut
-  # username-twitter:
+  username_github: https://github.com/DerGut
+  # username_twitter:
 
 
 links:

--- a/content/labs/paderborn.md
+++ b/content/labs/paderborn.md
@@ -1,27 +1,26 @@
 ---
 city: Paderborn
 title: CodeforPB
-lab: OK Lab Paderborn #needed for event and project aggregation
 markerposition: right
 
 members:
 
 - name: Arndt Heuvel
-  username-github: arndot
+  username_github: arndot
 
 - name: Arjun
-  username-github: Mellkor
+  username_github: Mellkor
 
 - name: Henrik Hüttemann
-  username-github: HerHde
-  username-twitter: herhde
+  username_github: HerHde
+  username_twitter: herhde
 
 - name: Jan Lippert
-  username-github: ironjan
-  username-twitter: lippertsjan
+  username_github: ironjan
+  username_twitter: lippertsjan
 
 - name: Michael
-  username-github: MichaelWhi
+  username_github: MichaelWhi
 
 
 links:

--- a/content/labs/ruhrgebiet.md
+++ b/content/labs/ruhrgebiet.md
@@ -1,7 +1,6 @@
 ---
 city: Ruhrgebiet
 title: OK Lab Ruhrgebiet
-lab: OK Lab Ruhrgebiet
 lat: 51.438531
 long: 7.024764
 markerposition: right
@@ -30,33 +29,33 @@ leads:
 
 members:
 - name: Ernesto Ruge
-  username-github: the-infinity
-  username-twitter: the_infinity
+  username_github: the-infinity
+  username_twitter: the_infinity
 - name: Martin Schurig
-  username-github: schurig
-  username-twitter: martinschurig
+  username_github: schurig
+  username_twitter: martinschurig
 - name: Benedict Zinke
-  username-github: bezin
-  username-twitter: b3zet
+  username_github: bezin
+  username_twitter: b3zet
 - name: Sakander Zirai
-  username-github: suioni
-  username-twitter: suioni
+  username_github: suioni
+  username_twitter: suioni
 - name: Simon Wörpel
-  username-github: simonwoerpel
-  username-twitter: simonwoerpel
+  username_github: simonwoerpel
+  username_twitter: simonwoerpel
 - name: Thomas Müller
-  username-github: mullerovsky
+  username_github: mullerovsky
 - name: Eugen Koslowski
-  username-github: dckoma
-  username-twitter: dckoma
+  username_github: dckoma
+  username_twitter: dckoma
 - name: Ulrich Greveler
-  username-github: greveler
-  username-twitter: greveler
+  username_github: greveler
+  username_twitter: greveler
 - name: Dennis Stacks
 - name: Tim Guenther
-  username-github: TimGuenther
-  username-twitter: t3gsec
+  username_github: TimGuenther
+  username_twitter: t3gsec
 - name: Benedikt Rauch
-  username-github: benediktrauch
-  username-twitter: pingubene
+  username_github: benediktrauch
+  username_twitter: pingubene
 ---

--- a/content/labs/schleswig-flensburg.md
+++ b/content/labs/schleswig-flensburg.md
@@ -1,7 +1,6 @@
 ---
 city: Schleswig-Flensburg
 title: OK Lab Kreis Schleswig-Flensburg
-lab: OK Lab Kreis Schleswig-Flensburg
 
 lat: 54.66414
 long: 9.40062
@@ -10,8 +9,8 @@ markerposition: right
 members:
 
 - name: Frank Radzio
-  username-github: DasNordlicht
-  username-twitter: dasnordlicht
+  username_github: DasNordlicht
+  username_twitter: dasnordlicht
   email: frank.radzio@nucleon-ev.eu
 
 - name: Jens Vorwerg
@@ -19,8 +18,8 @@ members:
   email: jens.vorwerg@nucleon-ev.eu
 
 - name: Marcel Radzio
-  username-github: mtrnord
-  username-twitter: mtrnord
+  username_github: mtrnord
+  username_twitter: mtrnord
 
 - name: Heinrich Rode
   email: heinrich.rode@nucleon-ev.eu

--- a/content/labs/stuttgart.md
+++ b/content/labs/stuttgart.md
@@ -1,45 +1,44 @@
 ---
 city: Stuttgart
 title: OK Lab Stuttgart
-lab: OK Lab Stuttgart
 lat: 48.776540
 long: 9.173700
 markerposition: right
 
 members:
 - name: Jan Lutz
-  username-twitter: Jan_sagt
-  username-github: fuergestalten
+  username_twitter: Jan_sagt
+  username_github: fuergestalten
 
 - name: Rajko Zschiegner
-  username-twitter: ricki_z
-  username-github: ricki-z
+  username_twitter: ricki_z
+  username_github: ricki-z
 
 - name: David Lackovic
 
 - name: Ewald Thoma
 
 - name: Frank Riedel
-  username-twitter: riedelwerk
-  username-github: riedelwerk
+  username_twitter: riedelwerk
+  username_github: riedelwerk
 
 - name: Martin Weis
-  username-github: Marwe
+  username_github: Marwe
 
 - name: Andreas Madsack
-  username-twitter: mfandreas
-  username-github: mfa
+  username_twitter: mfandreas
+  username_github: mfa
 
 - name: rashfael
-  username-github: rashfael
+  username_github: rashfael
 
 - name: Fritz Mielert
-  username-twitter: mielert
-  username-github: mielert
+  username_twitter: mielert
+  username_github: mielert
 
 - name: Christian Kuhn
-  username-twitter: ChrizKu
-  username-github: ChrizKu
+  username_twitter: ChrizKu
+  username_github: ChrizKu
 
 links:
 - name: Meetup
@@ -54,10 +53,10 @@ links:
 leads:
 - name: Jan Lutz
   url: mailto:jan.lutz@buero-fuer-gestalten.de
-  username-twitter: fuergestalten
-  username-github: fuergestalten
+  username_twitter: fuergestalten
+  username_github: fuergestalten
 - name: Rajko Zschiegner
   url: mailto:rajko@codefor.de
-  username-twitter: ricki_z
-  username-github: ricki-z
+  username_twitter: ricki_z
+  username_github: ricki-z
 ---

--- a/content/labs/ulm.md
+++ b/content/labs/ulm.md
@@ -10,35 +10,35 @@ markerposition: left
 members:
 
 - name: Benjamin Erb
-  username-github: berb
-  username-twitter: b_erb
+  username_github: berb
+  username_twitter: b_erb
 
 - name: Stefan Kaufmann
-  username-github: stkdiretto
-  username-twitter: _stk
+  username_github: stkdiretto
+  username_twitter: _stk
 
 - name: Falco Nogatz
-  username-github: fnogatz
-  username-twitter: ulmerleben
+  username_github: fnogatz
+  username_twitter: ulmerleben
 
 - name: Rens van der Heijden
-  username-github: namnatulco
-  username-twitter: namnatulco
+  username_github: namnatulco
+  username_twitter: namnatulco
 
 - name: Vincent Grünberg
-  username-github: e-drei
-  username-twitter: _e_drei
+  username_github: e-drei
+  username_twitter: _e_drei
 
 - name: Simon Fuchs
-  username-github: Taxilof
-  username-twitter: taxilof
+  username_github: Taxilof
+  username_twitter: taxilof
 
 - name: Henning Kopp
-  username-github: hkopp
+  username_github: hkopp
 
 - name: Juliane Wessalowski
-  username-github: gruenzeug
-  username-twitter: gruenzeug
+  username_github: gruenzeug
+  username_twitter: gruenzeug
 
 
 

--- a/content/labs/wuppertal.md
+++ b/content/labs/wuppertal.md
@@ -1,7 +1,6 @@
 ---
 city: Wuppertal
 title: OK Lab Wuppertal
-lab: OK Lab Wuppertal
 
 lat: 51.26687
 long: 7.14539
@@ -11,25 +10,25 @@ h4c: true
 members:
 
 - name: Nico Heßler
-  username-github: exmatrikulator
-  username-twitter: Exmatrikulat0r
+  username_github: exmatrikulator
+  username_twitter: Exmatrikulat0r
 - name: Daniel Fisher
-  username-github: lennybacon
-  username-twitter: lennybacon
+  username_github: lennybacon
+  username_twitter: lennybacon
 - name: Christopher Reinbothe
-  username-github: phsieben
-  username-twitter: phneutral
+  username_github: phsieben
+  username_twitter: phneutral
 - name: Bastian Pertz
-  username-github: Samisdat
-  username-twitter: Samisdat
+  username_github: Samisdat
+  username_twitter: Samisdat
 - name: Sam Zeini
-  username-github: SamZeini
-  username-twitter: SZeini
+  username_github: SamZeini
+  username_twitter: SZeini
 - name: Ralf Glörfeld
-  username-github: sn0wdiver
-  username-twitter: sn0wdiwer
+  username_github: sn0wdiver
+  username_twitter: sn0wdiwer
 - name: Cathy Klappert
-  username-twitter: CathyKlappert
+  username_twitter: CathyKlappert
 - name: Jan Niko Kirschbaum
 
 

--- a/content/projekte/2011-12-31-accessmap.md
+++ b/content/projekte/2011-12-31-accessmap.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [ berlin ] #needed for Aggregation on Lab-Page
 imgname: berlin/accessmap.jpg
 title: Access Map
 

--- a/content/projekte/2011-12-31-buergerbautstadt.md
+++ b/content/projekte/2011-12-31-buergerbautstadt.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/buergerbautstadt.png
 title: Buerger Baut Stadt
 showcase: 1

--- a/content/projekte/2011-12-31-ernteteilen.md
+++ b/content/projekte/2011-12-31-ernteteilen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/ernteteilen.png
 title: Ernte Teilen
 excerpt:

--- a/content/projekte/2013-08-05-hn-geojson-utilities.md
+++ b/content/projekte/2013-08-05-hn-geojson-utilities.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/geojson-utilities.png
 title: Geojson Utilities
 status: Finished

--- a/content/projekte/2014-02-22-hn-crimemap.md
+++ b/content/projekte/2014-02-22-hn-crimemap.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: hn-crimemap.jpg
 title: Diebstähle Region Heilbronn
 status: Finished

--- a/content/projekte/2014-02-22-hn-muellabfuhrtermine.md
+++ b/content/projekte/2014-02-22-hn-muellabfuhrtermine.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/recycling-map.png
 title: Recyclinghof-Finder
 status: Sucht Mitmacher

--- a/content/projekte/2014-03-22-hn-trinkwasser.md
+++ b/content/projekte/2014-03-22-hn-trinkwasser.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: hn-trinkwasser.jpg
 title: Was steckt in meinem Leitungswasser?
 showcase: 1

--- a/content/projekte/2014-04-04-Baustellen-Chemnitz.md
+++ b/content/projekte/2014-04-04-Baustellen-Chemnitz.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Chemnitz #needed for Aggregation on Lab-Page
+lab: [chemnitz] #needed for Aggregation on Lab-Page
 imgname: chemnitz/baustellen.png
 title: Karte Chemnitzer Baustellen
 status: Finished

--- a/content/projekte/2014-04-09-Berlin-Lichtenberg.md
+++ b/content/projekte/2014-04-09-Berlin-Lichtenberg.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/lichtenberg.jpg
 title: Kiez-Karte Berlin
 status: In Progress

--- a/content/projekte/2014-04-09-Vornamen.md
+++ b/content/projekte/2014-04-09-Vornamen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/vornamen-app.png
 title: Vornamen App
 status: Finished

--- a/content/projekte/2014-04-16-cctvwatch.md
+++ b/content/projekte/2014-04-16-cctvwatch.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/cctvwatch.jpg
 title: cctvwatch - big brother is watching you
 

--- a/content/projekte/2014-04-19-dd-freieparkplaetze.md
+++ b/content/projekte/2014-04-19-dd-freieparkplaetze.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Dresden #needed for Aggregation on Lab-Page
+lab: [dresden] #needed for Aggregation on Lab-Page
 imgname: dresden/parkhaeuser-web.png
 title: Freie Parkplätze Dresden
 showcase: 1

--- a/content/projekte/2014-04-19-dd-kitakarte.md
+++ b/content/projekte/2014-04-19-dd-kitakarte.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Dresden #needed for Aggregation on Lab-Page
+lab: [dresden] #needed for Aggregation on Lab-Page
 imgname: dresden/kita.png
 title: Kitakarte Dresden
 

--- a/content/projekte/2014-04-22-be-wahlversprechen.md
+++ b/content/projekte/2014-04-22-be-wahlversprechen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/wahlversprechen2013.jpg
 title: Wahlversprechen2013
 showcase: 1

--- a/content/projekte/2014-04-22-disabled-railway.md
+++ b/content/projekte/2014-04-22-disabled-railway.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/disabled-railways.png
 title: Disabled Railway
 

--- a/content/projekte/2014-04-24-rberlindata.md
+++ b/content/projekte/2014-04-24-rberlindata.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/rberlindata.png
 title: daten.berlin.de für R
 

--- a/content/projekte/2014-04-25-hh-laenderfinanzausgleich.md
+++ b/content/projekte/2014-04-25-hh-laenderfinanzausgleich.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Hamburg #needed for Aggregation on Lab-Page
+lab: [hamburg] #needed for Aggregation on Lab-Page
 imgname: hamburg/LFA.png
 title: Länderfinanzausgleich visualisieren
 

--- a/content/projekte/2014-04-27-hh-baumkataster.md
+++ b/content/projekte/2014-04-27-hh-baumkataster.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Hamburg #needed for Aggregation on Lab-Page
+lab: [hamburg] #needed for Aggregation on Lab-Page
 imgname: hamburg/baumkataster.jpg
 title: Baumkataster nutzen
 

--- a/content/projekte/2014-04-27-hh-kitaKarte.md
+++ b/content/projekte/2014-04-27-hh-kitaKarte.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Hamburg #needed for Aggregation on Lab-Page
+lab: [hamburg] #needed for Aggregation on Lab-Page
 imgname: hamburg/kitas.jpg
 title: Die passende Kita in Hamburg finden
 

--- a/content/projekte/2014-04-27-hh-spielplatzwuesten.md
+++ b/content/projekte/2014-04-27-hh-spielplatzwuesten.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Hamburg #needed for Aggregation on Lab-Page
+lab: [hamburg] #needed for Aggregation on Lab-Page
 imgname: hamburg/wueste.jpg
 title: Spielplatzwüsten kartieren
 showcase: 1

--- a/content/projekte/2014-04-28-dd-ratskarte.md
+++ b/content/projekte/2014-04-28-dd-ratskarte.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Dresden #needed for Aggregation on Lab-Page
+lab: [dresden] #needed for Aggregation on Lab-Page
 imgname: dresden/ratskarte.png
 title: Ratskarte Dresden
 status: Zwonull

--- a/content/projekte/2014-04-30-Maifeuer-Chemnitz.md
+++ b/content/projekte/2014-04-30-Maifeuer-Chemnitz.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Chemnitz #needed for Aggregation on Lab-Page
+lab: [chemnitz] #needed for Aggregation on Lab-Page
 imgname: chemnitz/maifeuer2014.png
 title: Maifeuer 2014 in Chemnitz
 status: Finished

--- a/content/projekte/2014-04-30-stolpersteine-app.md
+++ b/content/projekte/2014-04-30-stolpersteine-app.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/stolpersteine-app.jpg
 title: Stolpersteine App
 showcase: 1

--- a/content/projekte/2014-04-30-ulm-projekte.md
+++ b/content/projekte/2014-04-30-ulm-projekte.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Ulm #needed for Aggregation on Lab-Page
+lab: [ulm] #needed for Aggregation on Lab-Page
 imgname: ulm/Projekte.png
 title: Projekte rund um Ulm
 

--- a/content/projekte/2014-05-01-portable-linked-profiles.md
+++ b/content/projekte/2014-05-01-portable-linked-profiles.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/portablelinkedprofiles.png
 title: Portable Linked Profiles
 

--- a/content/projekte/2014-05-05-le-luftqualitaet_sachsen.md
+++ b/content/projekte/2014-05-05-le-luftqualitaet_sachsen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Leipzig #needed for Aggregation on Lab-Page
+lab: [leipzig] #needed for Aggregation on Lab-Page
 imgname: leipzig/messstation.jpg
 title: Luftqualität Sachsen
 status: Entwicklungsstand 2016

--- a/content/projekte/2014-05-06-le-kitas_und_schulen_in_leipzig.md
+++ b/content/projekte/2014-05-06-le-kitas_und_schulen_in_leipzig.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Leipzig #needed for Aggregation on Lab-Page
+lab: [leipzig] #needed for Aggregation on Lab-Page
 imgname: leipzig/kidsle.jpg
 title: Kitas und Schulen Verzeichnis Leipzig
 showcase: 1

--- a/content/projekte/2014-05-19-be-tempelhof.md
+++ b/content/projekte/2014-05-19-be-tempelhof.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/tempelhofer-feld.png
 title: Feld - die Bebauung des Tempelhofer Felds in 3D
 showcase: 1

--- a/content/projekte/2014-05-22-c-Haltestellen.md
+++ b/content/projekte/2014-05-22-c-Haltestellen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Chemnitz #needed for Aggregation on Lab-Page
+lab: [chemnitz] #needed for Aggregation on Lab-Page
 imgname: chemnitz/haltestellen.png
 title:  "Haltestellen in Chemnitz & Umland"
 status: Finished

--- a/content/projekte/2014-05-28-ms-wahlkarte.md
+++ b/content/projekte/2014-05-28-ms-wahlkarte.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Münster #needed for Aggregation on Lab-Page
+lab: [muenster] #needed for Aggregation on Lab-Page
 imgname: muenster/wahlkarte.png
 title: Ergebnisse der Kommunalwahl 2014
 

--- a/content/projekte/2014-06-04-hh-bruecken.md
+++ b/content/projekte/2014-06-04-hh-bruecken.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Hamburg #needed for Aggregation on Lab-Page
+lab: [hamburg] #needed for Aggregation on Lab-Page
 imgname: hamburg/bruecke.jpg
 title: Wie viele Brücken hat Hamburg?
 status: Fertig

--- a/content/projekte/2014-06-12-hn-buga.md
+++ b/content/projekte/2014-06-12-hn-buga.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/buga2019.jpg
 title: Buga2019-Visualisierung
 status: Sucht Mitmacher

--- a/content/projekte/2014-06-17-geodata-time.md
+++ b/content/projekte/2014-06-17-geodata-time.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/geodata-time.jpg
 title: Geodaten mit Zeitdimension
 

--- a/content/projekte/2014-06-17-hh-baualterskarte.md
+++ b/content/projekte/2014-06-17-hh-baualterskarte.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Hamburg #needed for Aggregation on Lab-Page
+lab: [hamburg] #needed for Aggregation on Lab-Page
 imgname: hamburg/baualter.jpg
 title: Wie alt sind die Hamburger Gebäude?
 status: Fertig

--- a/content/projekte/2014-06-17-umweltzone.md
+++ b/content/projekte/2014-06-17-umweltzone.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/umweltzone.png
 title: Umweltzone Android app
 status: Looking for people

--- a/content/projekte/2014-06-20-offenerrat.md
+++ b/content/projekte/2014-06-20-offenerrat.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Münster #needed for Aggregation on Lab-Page
+lab: [muenster] #needed for Aggregation on Lab-Page
 imgname: muenster/offener-rat.jpg
 title: Offener Rat Münster
 

--- a/content/projekte/2014-06-21-wahlprogramm-matrix.md
+++ b/content/projekte/2014-06-21-wahlprogramm-matrix.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Münster #needed for Aggregation on Lab-Page
+lab: [muenster] #needed for Aggregation on Lab-Page
 imgname: muenster/wahlprogramm-matrix-web.png
 title: Wahlprogramm-Matrix Kommunalwahl Münster 2014
 showcase: 1

--- a/content/projekte/2014-06-23-aedmap.md
+++ b/content/projekte/2014-06-23-aedmap.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/aedcgn.png
 title: Defibrillatoren in Köln
 showcase: 1

--- a/content/projekte/2014-06-23-trinkwasser.md
+++ b/content/projekte/2014-06-23-trinkwasser.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/wasser.png
 title: Trinkwasser in Köln
 status: Finished

--- a/content/projekte/2014-06-25-badeseen.md
+++ b/content/projekte/2014-06-25-badeseen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/berliner-badeseen.png
 title: Baden in Berlin
 

--- a/content/projekte/2014-06-25-historic-berlin.md
+++ b/content/projekte/2014-06-25-historic-berlin.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/entwicklung-berlin.png
 title: Historische Entwicklung Berlins
 

--- a/content/projekte/2014-06-26-altglas.md
+++ b/content/projekte/2014-06-26-altglas.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/altglas.png
 title: Altglas Container
 status: Verwaist, sucht Mitmacher

--- a/content/projekte/2014-06-30-hh-thingsonbikelanes.md
+++ b/content/projekte/2014-06-30-hh-thingsonbikelanes.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Hamburg #needed for Aggregation on Lab-Page
+lab: [hamburg] #needed for Aggregation on Lab-Page
 imgname: hamburg/thingsonbikelanes.png
 title: Things On Bikelanes
 

--- a/content/projekte/2014-07-01-be-blume.md
+++ b/content/projekte/2014-07-01-be-blume.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/blume.gif
 title: BLUME Messnetz API/Map
 

--- a/content/projekte/2014-07-01-le-lvz_polizeiticker_visualisierung.md
+++ b/content/projekte/2014-07-01-le-lvz_polizeiticker_visualisierung.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Leipzig #needed for Aggregation on Lab-Page
+lab: [leipzig] #needed for Aggregation on Lab-Page
 imgname: leipzig/polizeiticker.jpg
 title: Visualisierung der Polizeiticker Meldungen der Leipziger Volkszeitung
 showcase: 1

--- a/content/projekte/2014-07-03-Bodenrichtwerte.md
+++ b/content/projekte/2014-07-03-Bodenrichtwerte.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/bodenrichtwerte.png
 title: Bodenrichtwerte im Zeitverlauf
 

--- a/content/projekte/2014-07-04-Vornamen-in-Berlin.md
+++ b/content/projekte/2014-07-04-Vornamen-in-Berlin.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/vornamen.png
 title: Berliner Vornamen
 

--- a/content/projekte/2014-07-10-muc-finder.md
+++ b/content/projekte/2014-07-10-muc-finder.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab München #needed for event and project aggregation
+lab: [muenchen] #needed for event and project aggregation
 imgname: muenchen/finderapp-prototyp.png
 title: Web-App zum Finden von bestimmten Orten (u.a. Defibrilatoren) in der Umgebung
 status: Sucht Mitmacher
@@ -41,9 +41,3 @@ collaborators:
 Ziel des Projekts ist eine Web-App, die aus Open-Street-Map-Daten Orte einer bestimmten Kategorie, z.B. öffentliche Toiletten, Spielplätze oder Defibrilatoren in der Umgebung findet und dazu Routeninformationen bietet. Dabei soll es am Ende eine generische App, die für verschiedene Ziele konfiguriert werden kann, sowie als konkrete Anwendung eine Defibrilator-Finde-App geben.
 
 Der <a href="http://codeformunich.github.io/FinderApp/">aktuelle Prototyp</a> funktioniert für einfache Anfragen bereits (<a href="https://github.com/codeformunich/FinderApp#customisation">Anleitung für neue App</a>), für Defibrilatoren muss <a href="https://github.com/codeformunich/FinderApp/issues/57">Issue 57</a> noch umgesetzt werden.
-
-
-
-
-
-

--- a/content/projekte/2014-07-13-le-ratskarte_leipzig.md
+++ b/content/projekte/2014-07-13-le-ratskarte_leipzig.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Leipzig
+lab: [leipzig]
 imgname: leipzig/stadtratmonitor.jpg
 title: Stadtratmonitor Leipzig
 showcase: 1

--- a/content/projekte/2014-07-14-Muenchen-Transparent.md
+++ b/content/projekte/2014-07-14-Muenchen-Transparent.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab München #needed for event and project aggregation
+lab: [muenchen] #needed for event and project aggregation
 imgname: muenchen/Muenchen-Transparent.png
 title: München Transparent
 status: Im Produktivbetrieb

--- a/content/projekte/2014-07-14-newcomer.md
+++ b/content/projekte/2014-07-14-newcomer.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Gießen #needed for event and project aggregation
+lab: [giessen] #needed for event and project aggregation
 imgname: giessen/newcomer_mockup.png
 title: Newcomer in der Region Mittelhessen
 status: Laufend, Konzeptionierung, Datensammlung, Sucht Mitmacher

--- a/content/projekte/2014-07-21-dbpediaplacesberlin.md
+++ b/content/projekte/2014-07-21-dbpediaplacesberlin.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin
+lab: [berlin]
 imgname: berlin/dbpediaplacesberlin.jpg
 title: DBpedia Places Berlin
 

--- a/content/projekte/2014-07-28-gedenktafelnberlin.md
+++ b/content/projekte/2014-07-28-gedenktafelnberlin.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin
+lab: [berlin]
 imgname: berlin/gedenktafeln.jpg
 title: Gedenktafeln in Berlin
 

--- a/content/projekte/2014-08-19-badeseen.md
+++ b/content/projekte/2014-08-19-badeseen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Gießen #needed for event and project aggregation
+lab: [giessen] #needed for event and project aggregation
 imgname: giessen/badeseenapp.png
 title: Badeseen in Hessen
 status: Fertig
@@ -19,19 +19,19 @@ links:
 
 collaborators:
 - name: Christian Schulze
-  username-github: ChristianSch
+  username_github: ChristianSch
 - name: Christian Heigele
-  username-github: cheigele
+  username_github: cheigele
 - name: Prof. Dr. Martin Przewloka
 - name: Marco Schäfer
-  username-github: msfr
+  username_github: msfr
 - name: Vincent Elliott Wagner
-  username-github: serofax
+  username_github: serofax
 - name: Katharina Dort
 - name: Julian Schmitt
-  username-github: SteakMcFries
+  username_github: SteakMcFries
 - name: Florian Kolb
-  username-github: toxic2302
+  username_github: toxic2302
 
 
 ---

--- a/content/projekte/2014-08-19-pb-kneipen.md
+++ b/content/projekte/2014-08-19-pb-kneipen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Paderborn #needed for event and project aggregation
+lab: [paderborn] #needed for event and project aggregation
 imgname: paderborn/pb-kneipenplan.png
 title: Paderborner Kneipenplan
 

--- a/content/projekte/2014-09-03-abschiebungen.md
+++ b/content/projekte/2014-09-03-abschiebungen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin
+lab: [berlin]
 imgname: berlin/abschiebungen.jpg
 title: Abschiebungen
 

--- a/content/projekte/2014-09-12-flaechengerechtigkeit.md
+++ b/content/projekte/2014-09-12-flaechengerechtigkeit.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/flaechengerechtigkeit.png
 title: FLÄCHENGERECHTIGKEITS-TOOL
 

--- a/content/projekte/2014-09-22-hh-zuwendungen.md
+++ b/content/projekte/2014-09-22-hh-zuwendungen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Hamburg #needed for Aggregation on Lab-Page
+lab: [hamburg] #needed for Aggregation on Lab-Page
 imgname: hamburg/zuwendungen.jpg
 title: Die Zuwendungen der Hamburger Behörden.
 status: Festgefahren

--- a/content/projekte/2014-10-13-hh-echtzeit.md
+++ b/content/projekte/2014-10-13-hh-echtzeit.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Hamburg #needed for Aggregation on Lab-Page
+lab: [hamburg] #needed for Aggregation on Lab-Page
 imgname: hamburg/echtzeit.png
 title: Hamburg in Zahlen
 showcase: 1

--- a/content/projekte/2014-10-15-offener-haushalt-muenster.md
+++ b/content/projekte/2014-10-15-offener-haushalt-muenster.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Münster #needed for Aggregation on Lab-Page
+lab: [muenster] #needed for Aggregation on Lab-Page
 imgname: muenster/haushalt.png
 title: Offener Haushalt Münster 2009-2013
 showcase: 1

--- a/content/projekte/2014-11-02-be-wartezeit-moers.md
+++ b/content/projekte/2014-11-02-be-wartezeit-moers.md
@@ -1,8 +1,8 @@
 ---
 layout: project
 lab:
-  - OK Lab Berlin
-  - OK Lab Niederrhein
+  - berlin
+  - niederrhein
 imgname: berlin/wartezeit.png
 title: Wartezeit Moers
 status: Finished

--- a/content/projekte/2014-11-05-flaechentool.md
+++ b/content/projekte/2014-11-05-flaechentool.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/flaechentool.jpg
 title: Flächentool
 

--- a/content/projekte/2014-11-26-be-xmas.md
+++ b/content/projekte/2014-11-26-be-xmas.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/xmas.png
 title: Weihnachtsmärkte
 status: Finished

--- a/content/projekte/2014-11-29-hn-kastanienapp.md
+++ b/content/projekte/2014-11-29-hn-kastanienapp.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/kastanien-app.png
 title: Kastanienapp
 status: Finished

--- a/content/projekte/2014-12-04-ms-weihnachtsmarkt.md
+++ b/content/projekte/2014-12-04-ms-weihnachtsmarkt.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Münster #needed for Aggregation on Lab-Page
+lab: [muenster] #needed for Aggregation on Lab-Page
 imgname: muenster/weihnachtsmarkt.png
 title: Weihnachtsmarkt-App Münster 2014
 showcase: 1

--- a/content/projekte/2014-12-05-Blitzerkarte-Chemnitz.md
+++ b/content/projekte/2014-12-05-Blitzerkarte-Chemnitz.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Chemnitz #needed for Aggregation on Lab-Page
+lab: [chemnitz] #needed for Aggregation on Lab-Page
 imgname: chemnitz/blitzer.png
 title: Karte Chemnitzer Blitzer
 

--- a/content/projekte/2014-12-10-ms-parkleit-api.md
+++ b/content/projekte/2014-12-10-ms-parkleit-api.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Münster #needed for Aggregation on Lab-Page
+lab: [muenster] #needed for Aggregation on Lab-Page
 imgname:
 title: Parkleitsystem API Münster
 showcase: 1

--- a/content/projekte/2014-12-14-ffpb-krombel.md
+++ b/content/projekte/2014-12-14-ffpb-krombel.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Paderborn #needed for Aggregation on Lab-Page
+lab: [paderborn] #needed for Aggregation on Lab-Page
 imgname: paderborn/ffpb-krombel.png
 title: Krombels Dash auf Android
 

--- a/content/projekte/2014-12-15-pb-parking.md
+++ b/content/projekte/2014-12-15-pb-parking.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Paderborn #needed for Aggregation on Lab-Page
+lab: [paderborn] #needed for Aggregation on Lab-Page
 imgname: paderborn/pb-parking.png
 title: Parken in Paderborn
 status: Prototyp

--- a/content/projekte/2014-12-22-cologne-spielplaetze.md
+++ b/content/projekte/2014-12-22-cologne-spielplaetze.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/spielplaetze.jpg
 title: Spielplätze in Köln
 status: Laufend, Konzeptionierung, Sucht Mitmacher

--- a/content/projekte/2015-01-05-cologne-schulen-in-koeln.md
+++ b/content/projekte/2015-01-05-cologne-schulen-in-koeln.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/schueler.png
 title: Schulen in Köln
 status: Laufend, Sucht Mitmacher

--- a/content/projekte/2015-01-15-cologne-verkehr.md
+++ b/content/projekte/2015-01-15-cologne-verkehr.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/verkehr.png
 title: Verkehrsmeldungen Köln
 status: Laufend, Konzeptionierung, Datensammlung, Sucht Mitmacher

--- a/content/projekte/2015-01-15-muc-ddj.md
+++ b/content/projekte/2015-01-15-muc-ddj.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab München #needed for event and project aggregation
+lab: [muenchen] #needed for event and project aggregation
 imgname: muenchen/ddj.png
 title: How-To Datenjournalismus
 status: finished

--- a/content/projekte/2015-01-15-muc-defis.md
+++ b/content/projekte/2015-01-15-muc-defis.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab München #needed for event and project aggregation
+lab: [muenchen] #needed for event and project aggregation
 imgname: muenchen/defi-osm.png
 title: Defibrillatoren in OpenStreetMap eintragen (für FinderApp)
 status: Sucht Mitmacher
@@ -24,6 +24,6 @@ collaborators:
     name: github
 ---
 
-Die Standorte der Defis (AEDs) werden von diversen öffentlichen Stellen erfragt und in OpenStreetMap gemappt. Als zweiter Schritt soll die FinderApp damit gefüllt werden. 
+Die Standorte der Defis (AEDs) werden von diversen öffentlichen Stellen erfragt und in OpenStreetMap gemappt. Als zweiter Schritt soll die FinderApp damit gefüllt werden.
 
 Auf <a href="http://wiki.osm.org/München/Defi">Der Projektseite im OpenStreetMap-Wiki</a> befindet sich der Link zu einer Karte die den aktuellen Stand zeigt. Wir suchen noch Leute die in den U-Bahnhöfen erfassen, in welchen beiden Notrufsäulen pro Bahnsteig der Defibrilator verbaut ist.

--- a/content/projekte/2015-01-30-hh-demogenerator.md
+++ b/content/projekte/2015-01-30-hh-demogenerator.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Hamburg #needed for Aggregation on Lab-Page
+lab: [hamburg] #needed for Aggregation on Lab-Page
 imgname: hamburg/demofinder.png
 title: Demogenerator
 

--- a/content/projekte/2015-02-20-ka-strassennamen.md
+++ b/content/projekte/2015-02-20-ka-strassennamen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Karlsruhe #needed for Aggregation on Lab-Page
+lab: [karlsruhe] #needed for Aggregation on Lab-Page
 imgname: karlsruhe/strassennamen.png
 title: Straßennamen
 status: Finished

--- a/content/projekte/2015-02-21-hn-klickde.md
+++ b/content/projekte/2015-02-21-hn-klickde.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/klickde.png
 title: Klick Deutschland
 status: Finished

--- a/content/projekte/2015-02-21-hn-landtag.md
+++ b/content/projekte/2015-02-21-hn-landtag.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/landtag-watch.jpg
 title: Was macht mein Landtagsabgeordneter?
 status: Sucht Mitmacher

--- a/content/projekte/2015-02-21-hn-osm-editor.md
+++ b/content/projekte/2015-02-21-hn-osm-editor.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/osm-qa-editor.png
 title: OpenStreetMap QA Editor
 status: Finished

--- a/content/projekte/2015-02-23-ka-accessmap.md
+++ b/content/projekte/2015-02-23-ka-accessmap.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Karlsruhe #needed for Aggregation on Lab-Page
+lab: [karlsruhe] #needed for Aggregation on Lab-Page
 imgname: karlsruhe/access_map_ka.gif
 title: Access Map
 status: Finished

--- a/content/projekte/2015-03-02-ka-woistmarkt.md
+++ b/content/projekte/2015-03-02-ka-woistmarkt.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Karlsruhe #needed for Aggregation on Lab-Page
+lab: [karlsruhe] #needed for Aggregation on Lab-Page
 imgname: karlsruhe/wo-ist-markt.png
 title: Wo ist Markt?
 status: Finished

--- a/content/projekte/2015-03-09-wpt-offenerhaushalt.md
+++ b/content/projekte/2015-03-09-wpt-offenerhaushalt.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Wuppertal #needed for Aggregation on Lab-Page
+lab: [wuppertal] #needed for Aggregation on Lab-Page
 imgname: wuppertal/WPTHaushalt.PNG
 title: Offener Haushalt Wuppertal
 showcase: 1

--- a/content/projekte/2015-03-09-wpt-openbus.md
+++ b/content/projekte/2015-03-09-wpt-openbus.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Wuppertal #needed for Aggregation on Lab-Page
+lab: [wuppertal] #needed for Aggregation on Lab-Page
 imgname: wuppertal/OpenBus.PNG
 title: OpenBus
 status: Machbarkeitsstudie, Sucht Mitmacher

--- a/content/projekte/2015-03-09-wpt-talomat.md
+++ b/content/projekte/2015-03-09-wpt-talomat.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Wuppertal #needed for Aggregation on Lab-Page
+lab: [wuppertal] #needed for Aggregation on Lab-Page
 imgname: wuppertal/Talomat.PNG
 title: Talomat
 showcase: 1

--- a/content/projekte/2015-03-09-wpt-talso.md
+++ b/content/projekte/2015-03-09-wpt-talso.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Wuppertal #needed for Aggregation on Lab-Page
+lab: [wuppertal] #needed for Aggregation on Lab-Page
 imgname: wuppertal/Talso.PNG
 title: Tal, so?
 showcase: 1

--- a/content/projekte/2015-03-23-magdeburg-magdego.md
+++ b/content/projekte/2015-03-23-magdeburg-magdego.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Magdeburg #needed for Aggregation on Lab-Page
+lab: [magdeburg] #needed for Aggregation on Lab-Page
 imgname: magdeburg/magdego.de.png
 title: MagdeGo
 status: Discontinued

--- a/content/projekte/2015-03-23-magdeburg-rechte-gewalt.md
+++ b/content/projekte/2015-03-23-magdeburg-rechte-gewalt.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Magdeburg #needed for Aggregation on Lab-Page
+lab: [magdeburg] #needed for Aggregation on Lab-Page
 imgname: magdeburg/rechtegewalt.jpg
 title: Rechte Gewalt in Deutschland
 status: Finished

--- a/content/projekte/2015-04-07-bn-baustellen.md
+++ b/content/projekte/2015-04-07-bn-baustellen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Bonn #needed for Aggregation on Lab-Page
+lab: [bonn] #needed for Aggregation on Lab-Page
 imgname: bonn/baustellen-web.jpg
 title: Baustellen Übersicht
 showcase: 0

--- a/content/projekte/2015-04-07-bn-oepnv-tracking.md
+++ b/content/projekte/2015-04-07-bn-oepnv-tracking.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Bonn #needed for Aggregation on Lab-Page
+lab: [bonn] #needed for Aggregation on Lab-Page
 title: ÖPNV Tracking in Echtzeit
 showcase: 0
 status: In Progress

--- a/content/projekte/2015-04-07-bn-stolpersteine.md
+++ b/content/projekte/2015-04-07-bn-stolpersteine.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Bonn-Rhein-Sieg #needed for Aggregation on Lab-Page
+lab: [bonn] #needed for Aggregation on Lab-Page
 imgname: bonn/stolpersteine-web.jpg
 title: Visualisierung der Bonner Stolpersteine
 showcase: 0

--- a/content/projekte/2015-04-07-bn-veranstaltungskalender.md
+++ b/content/projekte/2015-04-07-bn-veranstaltungskalender.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Bonn #needed for Aggregation on Lab-Page
+lab: [bonn] #needed for Aggregation on Lab-Page
 title: Geographischer Veranstaltungskalender
 showcase: 0
 status: In Progress

--- a/content/projekte/2015-04-09-od-atlas.md
+++ b/content/projekte/2015-04-09-od-atlas.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/od-atlas.png
 title: Open Data Atlas
 status: In Progress

--- a/content/projekte/2015-04-10-jena-LinkedOpenHaushalt.md
+++ b/content/projekte/2015-04-10-jena-LinkedOpenHaushalt.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Jena
+lab: [jena]
 title: Linked Open Haushalt
 
 links:

--- a/content/projekte/2015-04-10-jena-OffenesRatsinformationssystem.md
+++ b/content/projekte/2015-04-10-jena-OffenesRatsinformationssystem.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Jena
+lab: [jena]
 title: Offener Stadtrat
 
 links:

--- a/content/projekte/2015-04-10-jena-VirtuellesJena.md
+++ b/content/projekte/2015-04-10-jena-VirtuellesJena.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Jena
+lab: [jena]
 imgname: jena/JenaMapillary.png
 title: Virtuelles Jena
 

--- a/content/projekte/2015-04-10-jena-save-o-meter.md
+++ b/content/projekte/2015-04-10-jena-save-o-meter.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Jena
+lab: [jena]
 title: Save-O-Meter
 
 links:

--- a/content/projekte/2015-04-11-ffpb-nodes.md
+++ b/content/projekte/2015-04-11-ffpb-nodes.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Paderborn #needed for Aggregation on Lab-Page
+lab: [paderborn] #needed for Aggregation on Lab-Page
 imgname: paderborn/ffpb-nodes.png
 title: Freifunk Knotenliste
 

--- a/content/projekte/2015-04-22-be-berliner-schulen.md
+++ b/content/projekte/2015-04-22-be-berliner-schulen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/berliner-schulen.png
 title: Berliner Schulen
 status: In Progress

--- a/content/projekte/2015-04-27-lieblingsplatz.md
+++ b/content/projekte/2015-04-27-lieblingsplatz.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/Lieblingsplatzlogo.png
 title: Lieblingsplatz
 

--- a/content/projekte/2015-04-28-stgt-dust-sensor.md
+++ b/content/projekte/2015-04-28-stgt-dust-sensor.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Stuttgart #needed for Aggregation on Lab-Page
+lab: [stuttgart] #needed for Aggregation on Lab-Page
 imgname: stuttgart/dust-sensor.jpg
 title: Feinstaubsensoren
 

--- a/content/projekte/2015-05-27-muc-mietpreisspiegel.md
+++ b/content/projekte/2015-05-27-muc-mietpreisspiegel.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab München #needed for event and project aggregation
+lab: [muenchen] #needed for event and project aggregation
 imgname: # TODO
 title: Mietpreisspiegel
 status: In Progress

--- a/content/projekte/2015-06-01-cologne-veranstaltungen.md
+++ b/content/projekte/2015-06-01-cologne-veranstaltungen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/veranstaltung.png
 title: Veranstaltungen in Köln
 status: Laufend, Sucht Mitmacher

--- a/content/projekte/2015-06-05-hn-bad-wimpfen-app.md
+++ b/content/projekte/2015-06-05-hn-bad-wimpfen-app.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/mein-badwimpfen.png
 title: City-App für Bad Wimpfen
 status: Finished

--- a/content/projekte/2015-06-09-stgt-efa-meta-api.md
+++ b/content/projekte/2015-06-09-stgt-efa-meta-api.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Stuttgart #needed for Aggregation on Lab-Page
+lab: [stuttgart] #needed for Aggregation on Lab-Page
 imgname: stuttgart/efa-meta-api.jpg
 title: Meta API für Elektonische Fahrplanauskunft
 status: Prototyp

--- a/content/projekte/2015-06-12-be-oparl.md
+++ b/content/projekte/2015-06-12-be-oparl.md
@@ -1,9 +1,9 @@
 ---
 layout: project
 lab:
-- OK Lab Berlin
-- OK Lab München
-- OK Lab Ruhrgebiet
+- berlin
+- muenchen
+- ruhrgebiet
 title: OParl
 imgname: berlin/oparl.png
 status: Released

--- a/content/projekte/2015-07-20-be-trinkwasser.md
+++ b/content/projekte/2015-07-20-be-trinkwasser.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin
+lab: [berlin]
 title: Trinkwasser Berlin
 imgname: berlin/trinkwasser.png
 

--- a/content/projekte/2015-08-08-be-feinstaub-sos.md
+++ b/content/projekte/2015-08-08-be-feinstaub-sos.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/feinstaub-sos.png
 title: SOS für Feinstaub-Daten
 status: In Arbeit

--- a/content/projekte/2015-08-30-aufbau-ostberlin.md
+++ b/content/projekte/2015-08-30-aufbau-ostberlin.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/aufbau-ostberlin.jpg
 title: Aufbau Ostberlin
 status: Laufend, sucht Mitmacher

--- a/content/projekte/2015-09-05-bn-bonn-o-mat.md
+++ b/content/projekte/2015-09-05-bn-bonn-o-mat.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Bonn #needed for Aggregation on Lab-Page
+lab: [bonn] #needed for Aggregation on Lab-Page
 imgname: bonn/bonn-o-mat.png
 title: BONN-O-MAT Wahlautomat für die Oberbürgermeisterwahl 2015
 status: Fertig

--- a/content/projekte/2015-09-15-vbb-api.md
+++ b/content/projekte/2015-09-15-vbb-api.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/vbb-cli.png
 title: VBB-API-Schnittstelle
 status: In Progress

--- a/content/projekte/2015-09-21-cologne-cute-pets.md
+++ b/content/projekte/2015-09-21-cologne-cute-pets.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/cutepets.png
 title: CutePetsCologne
 status: Finished

--- a/content/projekte/2015-09-21-cologne-denkmaeler.md
+++ b/content/projekte/2015-09-21-cologne-denkmaeler.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/denkmaeler.png
 title: Denkmal in Köln
 status: Finished

--- a/content/projekte/2015-09-28-bn-kinderbonn.md
+++ b/content/projekte/2015-09-28-bn-kinderbonn.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Bonn #needed for Aggregation on Lab-Page
+lab: [bonn] #needed for Aggregation on Lab-Page
 imgname: bonn/kinderbonn.png
 title: kinderbonn.de – Das Portal für Eltern, Kinder und Jugendliche aus Bonn und Umgebung
 status: In Progress

--- a/content/projekte/2015-10-05-cologne-daten-in-3D.md
+++ b/content/projekte/2015-10-05-cologne-daten-in-3D.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/koeln3d.jpg
 title: Kölner Daten in 3D
 status: Finished

--- a/content/projekte/2015-10-27-bn-air-quality-box.md
+++ b/content/projekte/2015-10-27-bn-air-quality-box.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Bonn #needed for Aggregation on Lab-Page
+lab: [bonn] #needed for Aggregation on Lab-Page
 imgname: bonn/air-quality-early-prototype.jpg
 title: Air Quality Box – Feinstaub und mehr messen
 status: In Progress

--- a/content/projekte/2015-12-15-ka-mietmap.md
+++ b/content/projekte/2015-12-15-ka-mietmap.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Karlsruhe #needed for Aggregation on Lab-Page
+lab: [karlsruhe] #needed for Aggregation on Lab-Page
 imgname: karlsruhe/mietmap.png
 title: Mietpreise in Karlsruhe
 status: Finished
@@ -17,4 +17,3 @@ collaborators:
 ---
 
 Dieses Projekt visualisiert auf einer Karte die Mietpreise in Karlsruhe auf Basis von Immobilienanzeigen.
-

--- a/content/projekte/2016-02-11-bn-opendatamap-nrw.md
+++ b/content/projekte/2016-02-11-bn-opendatamap-nrw.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Bonn #needed for Aggregation on Lab-Page
+lab: [bonn] #needed for Aggregation on Lab-Page
 imgname: bonn/opendataportalnrw.jpg
 title: Karte der Open Data – Angebote in NRW
 status: Finished
@@ -9,7 +9,7 @@ links:
 
 - url: http://data.paderta.com/OpenData-NRW-Map/
   name: Homepage / Karte
-  
+
 - url: https://github.com/daimpad/OpenData_Map_NRW
   name: GitHub Repository
 

--- a/content/projekte/2016-02-26-schulradar-ruhrgebiet.md
+++ b/content/projekte/2016-02-26-schulradar-ruhrgebiet.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Ruhrgebiet #needed for Aggregation on Lab-Page
+lab: [ruhrgebiet] #needed for Aggregation on Lab-Page
 imgname: ruhrgebiet/schulradar.jpg
 title: Schulradar Ruhrgebiet
 status: In Progress

--- a/content/projekte/2016-03-01-refugeeApp.md
+++ b/content/projekte/2016-03-01-refugeeApp.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Gießen #needed for Aggregation on Lab-Page
+lab: [giessen] #needed for Aggregation on Lab-Page
 imgname: giessen/refugeesGiessen.png
 title: Refugees Gießen
 status: Laufend, Datensammlung, Entwicklung, In Test

--- a/content/projekte/2016-03-03-dus-cycledorf.md
+++ b/content/projekte/2016-03-03-dus-cycledorf.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Düsseldorf
+lab: [duesseldorf]
 imgname: duesseldorf/cycledorf.png
 title: CycleDorf
 status: In Progress

--- a/content/projekte/2016-03-03-dus-ruhr-lernmedien-buddy.md
+++ b/content/projekte/2016-03-03-dus-ruhr-lernmedien-buddy.md
@@ -1,8 +1,8 @@
 ---
 layout: project
 lab:
-  - OK Lab Ruhrgebiet
-  - OK Lab Düsseldorf
+  - ruhrgebiet
+  - duesseldorf
 imgname: duesseldorf/lernmedien-buddy.png
 title: Lernmedien-Buddy
 status: In Progress

--- a/content/projekte/2016-03-05-hn-lk-wartezeiten.md
+++ b/content/projekte/2016-03-05-hn-lk-wartezeiten.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/wartezeiten.png
 title: Wartezeiten KFZ-Zulassungsstelle Heilbronn
 status: Finished

--- a/content/projekte/2016-03-05-schulen-in-nrw.md
+++ b/content/projekte/2016-03-05-schulen-in-nrw.md
@@ -1,8 +1,8 @@
 ---
 layout: project
 lab:
-  - OK Lab Ruhrgebiet
-  - OK Lab Niederrhein
+  - ruhrgebiet
+  - niederrhein
 imgname: ruhrgebiet/schulen-in-nrw.jpg
 title: Schulen in NRW
 status: In Progress

--- a/content/projekte/2016-03-14-be-woistmarkt.md
+++ b/content/projekte/2016-03-14-be-woistmarkt.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/wo-ist-markt.png
 title: Wo ist Markt?
 status: Finished

--- a/content/projekte/2016-03-19-le-woistmarkt.md
+++ b/content/projekte/2016-03-19-le-woistmarkt.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Leipzig #needed for Aggregation on Lab-Page
+lab: [leipzig] #needed for Aggregation on Lab-Page
 imgname: leipzig/woistmarkt.jpg
 title: Wo ist Markt?
 status: Daten von 2016

--- a/content/projekte/2016-04-26-dus-raumamateur.md
+++ b/content/projekte/2016-04-26-dus-raumamateur.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Düsseldorf
+lab: [duesseldorf]
 imgname: duesseldorf/raumamateur.png
 title: Raumamateur
 status: In Progress

--- a/content/projekte/2016-04-30-be-datenwaben.md
+++ b/content/projekte/2016-04-30-be-datenwaben.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/datenwaben.png
 title: Datenwaben
 status: In Progress
@@ -21,9 +21,9 @@ collaborators:
 
 ---
 
-Die moderne Art ein Datenportal darzustellen: Pro Datensatz wird eine Wabe dargestellt. 
+Die moderne Art ein Datenportal darzustellen: Pro Datensatz wird eine Wabe dargestellt.
 Mit einem bunten Hintergrund und kurzem Text können sowohl statische als auch Live-Daten angezeigt werden.<br />
 <br />
-Gestartet mit den Daten aus Berlin kann das Projekt auf weitere Städte ausgeweitet werden. 
+Gestartet mit den Daten aus Berlin kann das Projekt auf weitere Städte ausgeweitet werden.
 Dafür steht ein Backend zur Verfügung, dass die Erstellung weiterer Waben erleichtert.
 Hier kann jeder mitmachen - bei Problemen könnt ihr einfach nachfragen.

--- a/content/projekte/2016-05-30-cologne-kvbrad.md
+++ b/content/projekte/2016-05-30-cologne-kvbrad.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/kvbrad.jpeg
 title: KVB Fahrräder in Köln
 status: Laufend

--- a/content/projekte/2016-06-13-cologne-sagsunskoeln.md
+++ b/content/projekte/2016-06-13-cologne-sagsunskoeln.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/sagsunsapp-logo.png
 title: Sag's uns App Köln
 status: Laufend

--- a/content/projekte/2016-07-04-ffm-toiletsforthedisabled.md
+++ b/content/projekte/2016-07-04-ffm-toiletsforthedisabled.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Frankfurt #needed for Aggregation on Lab-Page
+lab: [frankfurt] #needed for Aggregation on Lab-Page
 imgname: frankfurt/toilets_for_the_disabled.png
 title: Toilets for the Disabled
 status: Laufend

--- a/content/projekte/2016-07-18-be-drl-empower-rangers.md
+++ b/content/projekte/2016-07-18-be-drl-empower-rangers.md
@@ -1,7 +1,7 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
-imgname: 
+lab: [berlin] #needed for Aggregation on Lab-Page
+imgname:
 title: Empower Rangers #Projekttitel
 status: Laufend
 type: DRL
@@ -9,7 +9,6 @@ draft: false
 
 ---
 
-Wir wollen den Verein <a href="http://www.refugeesemancipation.com">Refugees Emancipation</a> dabei unterstützen, noch bekannter zu werden. Deshalb wollen wir eine neue Webseite bauen, auf der sich der Verein präsentiert und auf der sich Bewohnerinnen und Bewohner von Unterkünften miteinander austauschen können. 
+Wir wollen den Verein <a href="http://www.refugeesemancipation.com">Refugees Emancipation</a> dabei unterstützen, noch bekannter zu werden. Deshalb wollen wir eine neue Webseite bauen, auf der sich der Verein präsentiert und auf der sich Bewohnerinnen und Bewohner von Unterkünften miteinander austauschen können.
 
 Refugees Emancipation betreibt in Unterkünften selbstverwaltete Internetcafés und gibt Kurse für NewcomerInnen.
-

--- a/content/projekte/2016-07-18-be-street-trees-api.md
+++ b/content/projekte/2016-07-18-be-street-trees-api.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/street-trees.png
 title: Street Trees API
 status: Sucht Mitmacher

--- a/content/projekte/2016-07-20-be-drl-refugeeworks.md
+++ b/content/projekte/2016-07-20-be-drl-refugeeworks.md
@@ -1,7 +1,7 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
-imgname: 
+lab: [berlin] #needed for Aggregation on Lab-Page
+imgname:
 title: RefugeesWork #Projekttitel
 status: Laufend
 type: DRL
@@ -18,6 +18,6 @@ links:
 
 ---
 
-RefugeesWork ist das Projekt eines interationalen Teams, das einen schnellen Einstieg ins Berufsleben für Newcomer ermöglichen will. Aus eigener Erfahrung konzentrieren sie sich dabei auf Angebote für Freelancer, die Unternehmen auf der Webseite <a href="http://www.refugeeswork.com/">refugeeswork.com</a> einstellen können. Außerdem unterstützt RefugeesWork bei der Arbeitssuche und hilft, wenn dabei Probleme mit der Bürokratie auftreten. 
+RefugeesWork ist das Projekt eines interationalen Teams, das einen schnellen Einstieg ins Berufsleben für Newcomer ermöglichen will. Aus eigener Erfahrung konzentrieren sie sich dabei auf Angebote für Freelancer, die Unternehmen auf der Webseite <a href="http://www.refugeeswork.com/">refugeeswork.com</a> einstellen können. Außerdem unterstützt RefugeesWork bei der Arbeitssuche und hilft, wenn dabei Probleme mit der Bürokratie auftreten.
 
 Hinter RefugeesWork stecken Alexander Praetorius,​ Nina Breznik​, Ali Ghali​, Thanh Nguyen, Alice Kohn​, Luka Tišler​, Henning Nugel, ​Jîwan Omar Abbas,​ Inga Schroeder, Caroline Peterson, Tanja Queckenstedt​, Sandra Herrmann​ und das Team von <a href="www.codingamigos.com<">www.codingamigos.com</a>.

--- a/content/projekte/2016-07-20-le-drl-amikeco.md
+++ b/content/projekte/2016-07-20-le-drl-amikeco.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Leipzig #needed for Aggregation on Lab-Page
+lab: [leipzig] #needed for Aggregation on Lab-Page
 imgname: leipzig/amikeco.jpg
 title: Amikeco #Projekttitel
 status: Entwicklungsstand 2016

--- a/content/projekte/2016-07-21-wpt-kartenkarte.md
+++ b/content/projekte/2016-07-21-wpt-kartenkarte.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Wuppertal #needed for Aggregation on Lab-Page
+lab: [wuppertal] #needed for Aggregation on Lab-Page
 imgname: wuppertal/kartenkarte.png
 title: KartenKarte
 status: In Progress

--- a/content/projekte/2016-07-21-wpt-talradparken.md
+++ b/content/projekte/2016-07-21-wpt-talradparken.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Wuppertal #needed for Aggregation on Lab-Page
+lab: [wuppertal] #needed for Aggregation on Lab-Page
 imgname: wuppertal/talradparken.png
 title: Talradparken
 status: Finished

--- a/content/projekte/2016-07-22-hn-codeweek.md
+++ b/content/projekte/2016-07-22-hn-codeweek.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/codeweek.jpg
 title: Code Week Heilbronn
 

--- a/content/projekte/2016-07-22-hn-farmbot.md
+++ b/content/projekte/2016-07-22-hn-farmbot.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/farmbot.jpg
 title: Farmbot // Code for Buga 2019
 

--- a/content/projekte/2016-07-22-hn-poetryslam.md
+++ b/content/projekte/2016-07-22-hn-poetryslam.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/poetryslam.png
 title: Poetry Slam
 

--- a/content/projekte/2016-07-23-metacollect.md
+++ b/content/projekte/2016-07-23-metacollect.md
@@ -1,9 +1,9 @@
 ---
 layout: project #do not change
-lab: OK Lab Berlin #change into your city/lab
+lab: [berlin] #change into your city/lab
 imgname: #add file to assets/projects/your city
-title: metacollect 
-status: Laufend 
+title: metacollect
+status: Laufend
 type: DRL
 draft: false #set to 'true'
 

--- a/content/projekte/2016-07-26-be-drl-volunteer-planner.md
+++ b/content/projekte/2016-07-26-be-drl-volunteer-planner.md
@@ -1,9 +1,9 @@
 ---
 layout: project #do not change
-lab: OK Lab Berlin #change into your city/lab
+lab: [berlin] #change into your city/lab
 imgname: berlin/volunteer-planer.png
-title: Volunteer-Planner 
-status: Laufend 
+title: Volunteer-Planner
+status: Laufend
 type: DRL
 draft: false #set to 'true'
 

--- a/content/projekte/2016-08-15-karlsruhe-drl-integrations-timeline.md
+++ b/content/projekte/2016-08-15-karlsruhe-drl-integrations-timeline.md
@@ -1,6 +1,6 @@
 ---
 layout: project #do not change
-lab: OK Lab Karlsruhe #change into your city/lab
+lab: [karlsruhe] #change into your city/lab
 imgname: #add file to assets/projects/your city
 title: Integrations-Timeline #project title
 status: Beendet

--- a/content/projekte/2016-08-15-karlsruhe-drl-schauhin.md
+++ b/content/projekte/2016-08-15-karlsruhe-drl-schauhin.md
@@ -1,6 +1,6 @@
 ---
 layout: project #do not change
-lab: OK Lab Karlsruhe #change into your city/lab
+lab: [karlsruhe] #change into your city/lab
 imgname: karlsruhe/schau-hin-website.png
 title: SchauHin mit der Antidiskriminierungsstelle #project title
 status: Finished

--- a/content/projekte/2016-08-15-karlsruhe-drl-welcome.md
+++ b/content/projekte/2016-08-15-karlsruhe-drl-welcome.md
@@ -1,6 +1,6 @@
 ---
 layout: project #do not change
-lab: OK Lab Karlsruhe #change into your city/lab
+lab: [karlsruhe] #change into your city/lab
 imgname: #add file to assets/projects/your city
 title: Welcome #project title
 status: Beendet

--- a/content/projekte/2016-08-22-ka-leitlinien-buergerbeteiligung.md
+++ b/content/projekte/2016-08-22-ka-leitlinien-buergerbeteiligung.md
@@ -1,7 +1,7 @@
 ---
 layout: project
-lab: OK Lab Karlsruhe #needed for Aggregation on Lab-Page
-imgname: 
+lab: [karlsruhe] #needed for Aggregation on Lab-Page
+imgname:
 title: Textanalyse von Leitlinien zur Bürger*innenbeteiligung
 status: Laufend
 
@@ -13,7 +13,7 @@ collaborators:
 
 ---
 
-Viele Städte haben Leitlinien oder Konzepte zur Bürger*innenbeteiligung. 
+Viele Städte haben Leitlinien oder Konzepte zur Bürger*innenbeteiligung.
 Wir wollen eine Plattform entwickeln, auf der diese strukturiert gelesen, kommentiert und entwickelt werden können.
 
 Technisch gesehen arbeiten wir mit Text-Extraktion mit Apache Tika und Indizierung/Volltextsuche mit Elastic Search. Dabei ist das Konzept natürlich für viele weitere Themen spannend - wir wollten mit einem überschaubaren Thema anfangen um Erfahrungen zu sammeln.

--- a/content/projekte/2016-09-13-be-schulsanierung.md
+++ b/content/projekte/2016-09-13-be-schulsanierung.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/schulsanierung.gif
 title: Wo unsere Kinder lernen
 status: Finished

--- a/content/projekte/2016-10-11-bahn-guru.md
+++ b/content/projekte/2016-10-11-bahn-guru.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin
+lab: [berlin]
 imgname: berlin/bahn-preiskalender.png
 title: Bahn-Guru
 status: In Progress

--- a/content/projekte/2016-10-11-mvg-rad-citybikes.md
+++ b/content/projekte/2016-10-11-mvg-rad-citybikes.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab München #needed for event and project aggregation
+lab: [muenchen] #needed for event and project aggregation
 imgname: muenchen/citybikes.jpg
 title: MVG Rad für citybik.es
 status: Im Produktivbetrieb

--- a/content/projekte/2016-10-31-cologne-pegelbot.md
+++ b/content/projekte/2016-10-31-cologne-pegelbot.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/pegelbot.png
 title: Pegelbot
 status: abgeschlossen

--- a/content/projekte/2016-11-28-cologne-openair.md
+++ b/content/projekte/2016-11-28-cologne-openair.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/openair.png
 title: OpenAir Cologne
 status: Laufend

--- a/content/projekte/2017-03-02-gi-mietspiegel.md
+++ b/content/projekte/2017-03-02-gi-mietspiegel.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Gießen #needed for Aggregation on Lab-Page
+lab: [giessen] #needed for Aggregation on Lab-Page
 imgname:
 title: Mietspiegel Gießen
 status: Datensammlung, Konzeptionierung, Sucht Mitmacher

--- a/content/projekte/2017-03-02-gi-muellkalender.md
+++ b/content/projekte/2017-03-02-gi-muellkalender.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Gießen #needed for Aggregation on Lab-Page
+lab: [giessen] #needed for Aggregation on Lab-Page
 imgname:
 title: Müllkalender App Gießen
 status: Datensammlung, Konzeptionierung, Sucht Mitmacher

--- a/content/projekte/2017-03-04-le-glaeserne-klaeranlage.md
+++ b/content/projekte/2017-03-04-le-glaeserne-klaeranlage.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Leipzig #needed for Aggregation on Lab-Page
+lab: [leipzig] #needed for Aggregation on Lab-Page
 imgname: leipzig/glaesernes_klaerwerk.png
 title: Gläsernes Klärwerk
 showcase: 1

--- a/content/projekte/2017-03-04-le-trinkwasser.md
+++ b/content/projekte/2017-03-04-le-trinkwasser.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Leipzig #needed for Aggregation on Lab-Page
+lab: [leipzig] #needed for Aggregation on Lab-Page
 imgname: leipzig/trinkwasser.jpg
 title: Was steckt in meinem Leitungswasser?
 showcase: 1

--- a/content/projekte/2017-04-28-ka-kommunale-haushalte-bw.md
+++ b/content/projekte/2017-04-28-ka-kommunale-haushalte-bw.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Karlsruhe #needed for Aggregation on Lab-Page
+lab: [karlsruhe] #needed for Aggregation on Lab-Page
 title: Kommunale Haushalte Baden-Württemberg
 
 links:
@@ -12,4 +12,3 @@ collaborators:
 
 ---
 Maschinenlesbare Varianten des kommunalen Produktplans Baden-Württemberg und der Verwaltungsvorschrift Produkt- und Kontenrahmen
-

--- a/content/projekte/2017-05-23-wahllokalfinder.md
+++ b/content/projekte/2017-05-23-wahllokalfinder.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 title: Wahllokalfinder
 status: Laufend
 type: WS

--- a/content/projekte/2017-05-24-wahlprogrammat.md
+++ b/content/projekte/2017-05-24-wahlprogrammat.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/wahlprogrammquiz.png
 title: Wahlprogrammquiz
 status: Laufend

--- a/content/projekte/2017-05-24-wepublic.md
+++ b/content/projekte/2017-05-24-wepublic.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/wepublic.png
 title: Wepublic
 status: Laufend
@@ -18,7 +18,7 @@ links:
   name: Facebook
 - url: mailto:hello@wepublic.me
   name: Kontakt
-  
+
 
 
 

--- a/content/projekte/2017-05-29-Beispiel.md
+++ b/content/projekte/2017-05-29-Beispiel.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/beispiel.png
 title: Beispielprojekt
 status: Laufend
@@ -17,14 +17,14 @@ links:
 collaborators:
 - name: Fiona Krakenbürger
 - name: Jan Kus
-- name: 
+- name:
 
 ---
 
 Dies ist ein Beispielprojekt. Beschreibt hier, worum es in eurem Projekt geht.
 
 - Erstellt eine Kopie dieser Datei
-- Benennt sie um 
+- Benennt sie um
 - ergänzt die Infos oben im Header
 - legt ggf. ein Bild ab unter assets/projects/koeln/
 - setzt "published" auf "true"

--- a/content/projekte/2017-05-29-wahldatentransparenzranking.md
+++ b/content/projekte/2017-05-29-wahldatentransparenzranking.md
@@ -1,14 +1,14 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 title: Wahldatentransparenzranking
 status: Laufend
 type: WS
 draft: false #set to 'true'
 
 links:
-- url: 
-  name: 
+- url:
+  name:
 
 collaborators:
 - name: Ulrike (dataista@gmail.com), Boris

--- a/content/projekte/2017-06-11-frankfurt-was-bekomme-ich-fuer-meine-miete.md
+++ b/content/projekte/2017-06-11-frankfurt-was-bekomme-ich-fuer-meine-miete.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Frankfurt #needed for Aggregation on Lab-Page
+lab: [frankfurt] #needed for Aggregation on Lab-Page
 imgname: frankfurt/Was_bekomme_ich in_Frankfurt_fuer_meine_Miete.png
 title: Was bekomme ich in Frankfurt für meine Miete?
 status: Abgeschlossen

--- a/content/projekte/2017-06-12-frankfurt-parkendd.md
+++ b/content/projekte/2017-06-12-frankfurt-parkendd.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Frankfurt #needed for Aggregation on Lab-Page
+lab: [frankfurt] #needed for Aggregation on Lab-Page
 imgname: frankfurt/parkendd-frankfurt.png
 title: Real-time parking lot app for Frankfurt am Main
 status: Abgeschlossen

--- a/content/projekte/2017-07-07-twitterdashboard.md
+++ b/content/projekte/2017-07-07-twitterdashboard.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Bonn #needed for Aggregation on Lab-Page
+lab: [bonn] #needed for Aggregation on Lab-Page
 imgname: bonn/twitterDash.png
 title: Twitter Dashboard
 status: Laufend
@@ -17,7 +17,7 @@ links:
 collaborators:
 - name: Damian
 - name: Wido
-- name: 
+- name:
 
 ---
 

--- a/content/projekte/2017-07-07-wahlbeteiligung.md
+++ b/content/projekte/2017-07-07-wahlbeteiligung.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 title: Wahlbeteiligung
 status: Laufend
 type: WS
@@ -18,4 +18,4 @@ collaborators:
 
 ---
 
-Das Projekt wahlbeteiligung soll die Wahlbeteiligung auf einer Karte veranschaulichen. Es soll darüber hinaus Eigenschaften der Umgebung dazu in Bezug setzen. 
+Das Projekt wahlbeteiligung soll die Wahlbeteiligung auf einer Karte veranschaulichen. Es soll darüber hinaus Eigenschaften der Umgebung dazu in Bezug setzen.

--- a/content/projekte/2017-07-07-wahlometer.md
+++ b/content/projekte/2017-07-07-wahlometer.md
@@ -1,8 +1,8 @@
 ---
 layout: project
 lab: # needed for Aggregation on Lab-Page
-  - OK Lab Ruhrgebiet
-  - OK Lab Köln 
+  - ruhrgebiet
+  - koeln
 title: Wahl-O-Meter
 status: Laufend
 type: WS # Tag for Wahlsalons
@@ -17,4 +17,4 @@ links:
 
 ---
 
-Im Rahmen der Wahlsalons soll im Datenschatz der Wahl-O-Maten der Bundeszentrale für politische Bildung geschürft werden: Die Daten werden aufbereitet und zueinander in Beziehung gesetzt, ein offenes JSON-Datenformat zur Definition von politischen Positionen abgeleitet und veröffentlicht. 
+Im Rahmen der Wahlsalons soll im Datenschatz der Wahl-O-Maten der Bundeszentrale für politische Bildung geschürft werden: Die Daten werden aufbereitet und zueinander in Beziehung gesetzt, ein offenes JSON-Datenformat zur Definition von politischen Positionen abgeleitet und veröffentlicht.

--- a/content/projekte/2017-07-15-hn-stolpersteine.md
+++ b/content/projekte/2017-07-15-hn-stolpersteine.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn # needed for Aggregation on Lab-Page
+lab: [heilbronn] # needed for Aggregation on Lab-Page
 imgname: heilbronn/stolperstein.png
 title: Stolpersteine in Heilbronn
 status: Finished

--- a/content/projekte/2017-07-24-wahlkompass-digitales.md
+++ b/content/projekte/2017-07-24-wahlkompass-digitales.md
@@ -1,8 +1,8 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/Wahlkompass.png
-title: Wahlkompass Digitales 
+title: Wahlkompass Digitales
 status: Laufend
 type: WS
 draft: false #set to 'true'

--- a/content/projekte/2017-09-15-zuwendungen.md
+++ b/content/projekte/2017-09-15-zuwendungen.md
@@ -1,5 +1,6 @@
 ---
 layout: project
+lab: [bremen]
 imgname: bremen/zuwendungen.png
 title: Zuwendungsdatenbank
 status: Abgeschlossen

--- a/content/projekte/2017-09-21-cologne-kulturpfade.md
+++ b/content/projekte/2017-09-21-cologne-kulturpfade.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/kulturpfadekoeln.jpg
 title: Kulturpfade Köln
 status: Laufend, Konzeptionierung, Datensammlung, Sucht Mitmacher

--- a/content/projekte/2017-09-24-bundestagswahl.md
+++ b/content/projekte/2017-09-24-bundestagswahl.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Köln #needed for Aggregation on Lab-Page
+lab: [koeln] #needed for Aggregation on Lab-Page
 imgname: koeln/waswenn.png
 title: was wäre wenn
 status: abgeschlossen

--- a/content/projekte/2017-09-24-wahlkarte-ka.md
+++ b/content/projekte/2017-09-24-wahlkarte-ka.md
@@ -1,7 +1,7 @@
 ---
 layout: project
-lab: OK Lab Karlsruhe #needed for Aggregation on Lab-Page
-imgname: 
+lab: [karlsruhe] #needed for Aggregation on Lab-Page
+imgname:
 title: Karlsruher Wahlanzeiger
 status: abgeschlossen
 type: WS

--- a/content/projekte/2017-09-24-wahlwatch-ka.md
+++ b/content/projekte/2017-09-24-wahlwatch-ka.md
@@ -1,7 +1,7 @@
 ---
 layout: project
-lab: OK Lab Karlsruhe #needed for Aggregation on Lab-Page
-imgname: 
+lab: [karlsruhe] #needed for Aggregation on Lab-Page
+imgname:
 title: Wahlwatching Twitter-Bot
 status: abgeschlossen
 type: WS

--- a/content/projekte/2017-10-08-karlsruhe-btw2017-stadtteile.md
+++ b/content/projekte/2017-10-08-karlsruhe-btw2017-stadtteile.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Karlsruhe #needed for Aggregation on Lab-Page
+lab: [karlsruhe] #needed for Aggregation on Lab-Page
 imgname: karlsruhe/btw2017-stadtteile.png
 title: Die Bundestagswahl 2017 in den Karlsruher Stadtteilen
 status: abgeschlossen
@@ -19,4 +19,3 @@ collaborators:
 ---
 
 Jeder Karlsruher Stadtteil ist anders — wie hat sich das auf die Wahl ausgewirkt? Wir haben uns das an Hand verschiedener Statistiken genauer angeschaut.
-

--- a/content/projekte/2017-10-09-ka-open-sense.md
+++ b/content/projekte/2017-10-09-ka-open-sense.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Karlsruhe #needed for Aggregation on Lab-Page
+lab: [karlsruhe] #needed for Aggregation on Lab-Page
 imgname: karlsruhe/open_sense.png
 title: Open Sense
 status: Laufend

--- a/content/projekte/2017-11-15-ruhrgebiet-blitzerkarte.md
+++ b/content/projekte/2017-11-15-ruhrgebiet-blitzerkarte.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Ruhrgebiet
+lab: [ruhrgebiet]
 imgname: ruhrgebiet/blitzerkarte.jpg
 title: Blitzerkarte
 status: Laufend

--- a/content/projekte/2017-11-15-ruhrgebiet-recyclingkarte.md
+++ b/content/projekte/2017-11-15-ruhrgebiet-recyclingkarte.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Ruhrgebiet
+lab: [ruhrgebiet]
 imgname: ruhrgebiet/recyclingkarte.png
 title: Recyclingkarte
 status: in Entwicklung

--- a/content/projekte/2018-01-06-pricemap-eu.md
+++ b/content/projekte/2018-01-06-pricemap-eu.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin
+lab: [berlin]
 imgname: berlin/pricemap-eu.png
 title: Bahn- und Buspreiskarte
 status: In Progress

--- a/content/projekte/2018-01-11-meine-stadt-transparent.md
+++ b/content/projekte/2018-01-11-meine-stadt-transparent.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab München #needed for event and project aggregation
+lab: [muenchen] #needed for event and project aggregation
 title: Meine Stadt Transparent
 status: In Progress
 
@@ -38,7 +38,7 @@ Meine Stadt Transparent ist ein vom [Prototype Fund](https://prototypefund.de) g
 
 Alle großen Städte und viele Gemeinden verwalten ihre Ratsarbeit in sogenannten Ratsinformationssystemen, zu denen es in der Regel auch einen öffentlichen Zugriff gibt. Leider sind fast alle dieser Systeme veraltet und für Bürger und Politiker gleichermaßen schlecht zu bedienen, weshalb es einige Initiativen gab und gibt, die alternative System entwickelt haben. Diese sind zwar oft beliebter als die Originalsysteme, haben jedoch Probleme wie eine zu starke Anpassung an eine Stadt, veraltete Software, dem Fehlen entscheidender Funktionen und natürlich chronischem Zeitmangel. Was fehlt ist eine moderne Plattform, die flexibel einsetzbar und für jedermann leicht zu bedienen ist.
 
-## Wie wird Dein Projekt dieses Problem lösen?    
+## Wie wird Dein Projekt dieses Problem lösen?
 
 In diesem Projekt soll der Prototyp eines neuen Ratsinformationssystems (RIS) entwickelt werden. Es geht dabei explizit nicht darum, einen vollständigen Ersatz für existierende Ratsinformationssysteme zu entwickeln. Stattdessen soll eine konkrete Plattform geschaffen werden, in die man mit geringem Aufwand eigene Daten importieren kann und die außerdem leicht anpassbar ist. Das System sollte sich in beliebigen deutschen Städten und Kommunen verwenden lassen. Zentral ist neben einer leicht verständlichen Weboberfläche eine mächtige Suche, da sonst die schiere Zahl an Dokumenten eine effektive Recherche verhindert. So gibt es z.B. allein im Münchner RIS über 180.000 Dokumente.
 Den Bedarf für eine solche Plattform zeigen die Projekte München Transparent, kleineanfragen.de und Politik bei Uns. Diese haben täglich jeweils mehrere hundert Nutzer und erhalten viel positives Feedback von Bürgern, Politikern, Verwaltungsmitarbeitern und Journalisten. Auch gab es viele Städten Ansätze, das RIS zu verbessern, die von einer fertigen Plattform stark profitieren würden. Ein wichtiger Aspekt dieses Projekts ist daher auch der regelmäßige Austausch mit potentiellen Nutzern.

--- a/content/projekte/2018-02-08-hn-lorawan.md
+++ b/content/projekte/2018-02-08-hn-lorawan.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Heilbronn #needed for Aggregation on Lab-Page
+lab: [heilbronn] #needed for Aggregation on Lab-Page
 imgname: heilbronn/lorawan.jpg
 title: LoRaWAN Gateways in Heilbronn
 

--- a/content/projekte/2018-02-21-radlquartier.md
+++ b/content/projekte/2018-02-21-radlquartier.md
@@ -1,13 +1,13 @@
 ---
 layout: project
-lab: "OK Lab München"
+lab: [muenchen]
 status: "In Progress"
 title: "Radlquartier München"
 imgname: muenchen/radlquartier.png
 
 collaborators:
 - name: "Manuel Hartmann"
-  links: 
+  links:
   - url: "https://twitter.com/bAck_mumu"
     name: Twitter
   - url: "https://github.com/bAckmumu"
@@ -19,7 +19,7 @@ collaborators:
     - url: "https://francisstieglitz.de/"
       name: Homepage
 
-links: 
+links:
 - name: "mvg.manuel.red (Webseite)"
   url: "http://mvg.manuel.red"
 - name: "Github (JavaScript-Projekt)"
@@ -32,4 +32,3 @@ links:
 Aufbereitung und Auswertung von Bikesharing Daten. Im Moment können MVG Rad Daten ausgewertet werden, das Ziel des Projekts ist es ein einheitliches Datenformat für die Aufbereitung von Bikesharing-Daten zu schaffen. Damit wird die Auswertung vereinfacht und unterschiedliche Bikesharing Dienste können miteinander verglichen werden.
 
 mvg.manuel.red zeigt die ersten Ergebnisse.
-

--- a/content/projekte/2018-04-09-fis-broker.md
+++ b/content/projekte/2018-04-09-fis-broker.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/fis-broker.jpg
 title: Daten aus dem Geoportal Berlin
 

--- a/content/projekte/2018-05-29-denkmal-magdeburg.md
+++ b/content/projekte/2018-05-29-denkmal-magdeburg.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Magdeburg #needed for Aggregation on Lab-Page
+lab: [magdeburg] #needed for Aggregation on Lab-Page
 title: Denkmal Magdeburg
 status: MVP
 

--- a/content/projekte/2018-20-06-direktvermarkter-karte.md
+++ b/content/projekte/2018-20-06-direktvermarkter-karte.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Karlsruhe #needed for Aggregation on Lab-Page
+lab: [karlsruhe] #needed for Aggregation on Lab-Page
 imgname: karlsruhe/direktvermarkter.png
 title: farmshops.eu Direktvermarkter Karte
 showcase: 1
@@ -24,7 +24,7 @@ links:
 
 ---
 
-Übersichtskarte von Hofläden, Märkten, Milchautomaten und anderen Direktvermarktern aus der DACH-Region (Deutschland, Österreich, Schweiz). Die Karte erhält alle ihre Daten über ein Script von Openstreetmap, bereitet sie optisch auf und unterstützt die Pflege der Daten indem sie fehlende Werte sichtbar macht und direkt auf den entsprechenden Ort auf OSM und in andere Kartendienste verlinkt. 
+Übersichtskarte von Hofläden, Märkten, Milchautomaten und anderen Direktvermarktern aus der DACH-Region (Deutschland, Österreich, Schweiz). Die Karte erhält alle ihre Daten über ein Script von Openstreetmap, bereitet sie optisch auf und unterstützt die Pflege der Daten indem sie fehlende Werte sichtbar macht und direkt auf den entsprechenden Ort auf OSM und in andere Kartendienste verlinkt.
 
 Fehlende Orte können auf Openstreetmap über die Tags shop=farm, amenity=vending_machine (vending=milk oder vending=food,...) oder amenity=marketplace nachgetragen werden. Details dazu findest Du im Menü der Karte.
 

--- a/content/projekte/2018-23-09-aufbau-von-lorawan-gateways-im-laendlichen-raum.md
+++ b/content/projekte/2018-23-09-aufbau-von-lorawan-gateways-im-laendlichen-raum.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Kreis Schleswig-Flensburg #needed for Aggregation on Lab-Page
+lab: ["schleswig-flensburg"] #needed for Aggregation on Lab-Page
 title: Aufbau von LoRaWAN Gateways im ländlichen Raum
 imgname: schleswig_flensburg/LoRaWan-Gateway.jpg
 showcase: 1

--- a/content/projekte/2018-24-11-1000-lorawan-nodes-im-laendlichen-raum.md
+++ b/content/projekte/2018-24-11-1000-lorawan-nodes-im-laendlichen-raum.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Kreis Schleswig-Flensburg #needed for Aggregation on Lab-Page
+lab: ["schleswig-flensburg"] #needed for Aggregation on Lab-Page
 title: 1000 LoRaWAN Nodes im ländlichen Raum von Schleswig-Holstein
 imgname: schleswig_flensburg/node.jpg
 showcase: 1

--- a/content/projekte/2019-01-01-magdeburg-baumfreunde-md.md
+++ b/content/projekte/2019-01-01-magdeburg-baumfreunde-md.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Magdeburg #needed for Aggregation on Lab-Page
+lab: [magdeburg] #needed for Aggregation on Lab-Page
 imgname: magdeburg/Baumfreunde-MD.png
 title: Baumfreunde-MD
 status: Active

--- a/content/projekte/2019-01-07-grossstadtbaum.md
+++ b/content/projekte/2019-01-07-grossstadtbaum.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/grossstadtbaum.jpg
 title: Großstadt-Baum
 showcase: 1

--- a/content/projekte/2019-02-01-magdeburg-magd-o-mat.md
+++ b/content/projekte/2019-02-01-magdeburg-magd-o-mat.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Magdeburg #needed for Aggregation on Lab-Page
+lab: [magdeburg] #needed for Aggregation on Lab-Page
 imgname: magdeburg/magdomat.png
 title: Magd-O-Mat
 status: Active

--- a/content/projekte/2019-02-18-quereinsteigende.md
+++ b/content/projekte/2019-02-18-quereinsteigende.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/quereinsteigende.gif
 title: Quereinsteigende
 showcase: 0

--- a/content/projekte/2019-04-01-open-legal-data.md
+++ b/content/projekte/2019-04-01-open-legal-data.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin #needed for Aggregation on Lab-Page
+lab: [berlin] #needed for Aggregation on Lab-Page
 imgname: berlin/open-legal-data.png
 title: Open Legal Data
 showcase: 0
@@ -27,5 +27,5 @@ collaborators:
 
 Open Legal Data ist eine freie juristische Datenbank für Gesetze und Urteile.
 
-Obwohl Urteile im Namen des Volkes ergehen, werden sie oft nur in kommerziellen Datenbanken oder gar nicht veröffentlicht. Deshalb sammeln wir Urteile und veröffentlichen sie für die Allgemeinheit frei zugänglich als Open Data. 
-Auf diese Weise wollen wir unabhängige Statistiken über die deutsche Rechtsprechung ermöglichen und so die Justiz transparenter machen. Alle Inhalte sind über eine API abrufbar und können mit Hilfe von uns zur Verfügung gestellten Tools analyisiert werden. 
+Obwohl Urteile im Namen des Volkes ergehen, werden sie oft nur in kommerziellen Datenbanken oder gar nicht veröffentlicht. Deshalb sammeln wir Urteile und veröffentlichen sie für die Allgemeinheit frei zugänglich als Open Data.
+Auf diese Weise wollen wir unabhängige Statistiken über die deutsche Rechtsprechung ermöglichen und so die Justiz transparenter machen. Alle Inhalte sind über eine API abrufbar und können mit Hilfe von uns zur Verfügung gestellten Tools analyisiert werden.

--- a/content/projekte/2019-11-18-zug-direktverbindungen.md
+++ b/content/projekte/2019-11-18-zug-direktverbindungen.md
@@ -1,6 +1,6 @@
 ---
 layout: project
-lab: OK Lab Berlin
+lab: [berlin]
 imgname: berlin/zug-direktverbindungen.png
 title: Zug-Direktverbindungen
 status: Finished

--- a/layouts/labs/list.html
+++ b/layouts/labs/list.html
@@ -14,7 +14,7 @@
         </div>
         <div class="column is-5">
           <h3 class="title is-5">In diesen Städten gibt es bereits ein OK Lab:</h3>
-          <div class="labs-list">
+          <div class="labs-list tags">
             {{ range .Pages.ByParam "city" }}
             <a href="{{.Permalink}}">
               <span class="tag lab-tag">{{.Params.city}}</span>

--- a/layouts/labs/list.html
+++ b/layouts/labs/list.html
@@ -14,13 +14,13 @@
         </div>
         <div class="column is-5">
           <h3 class="title is-5">In diesen Städten gibt es bereits ein OK Lab:</h3>
-          {{ range .Pages.ByParam "city" }}
-         <a href="{{.Permalink}}"> <span class="tag is-info">
-
-            {{.Params.city}}
-          </span>
-          </a>
-          {{ end }}
+          <div class="labs-list">
+            {{ range .Pages.ByParam "city" }}
+            <a href="{{.Permalink}}">
+              <span class="tag lab-tag">{{.Params.city}}</span>
+            </a>
+            {{ end }}
+          </div>
         </div>
     </div>
   </section>

--- a/layouts/labs/single.html
+++ b/layouts/labs/single.html
@@ -1,0 +1,78 @@
+{{ define "main"}}
+  <section class="section">
+    <div class="container">
+      <div class="columns">
+        <div class="column is-centered-tablet-portrait">
+          <h1 class="title section-title">{{ .Title }}
+            <div class="tags">
+            {{ range .Params.links }}
+              {{ if .top }}
+              <a href="{{.url}}">
+                <span class="tag has-text-weight-light">{{.name}}</span>
+              </a>
+              {{ end}}
+            {{ end}}
+            </div>
+          </h1>
+          </ul>
+          <div class="divider"></div>
+        </div>
+      </div>
+      <div class="columns">
+        <div class="column content is-8">
+          {{ .Content }}
+        </div>
+        <div class="column is-4 sidebar">
+          <h4 class="title is-4">Weitere Informationen</h4>
+          <h5 class="is-size-4">Mitglieder</h5>
+          <div class="sidebar-list">
+          {{ range sort .Params.members "name" }}
+          <div>{{ .name }}
+            [{{ if .username_github }}<a class="is-inline" href="https://github.com/{{ .username_github }}">GitHub</a>
+             {{ end }}{{ if .username_twitter }} <a class="is-inline" href="https://twitter.com/{{ .username_twitter }}">Twitter</a class="is-inline">{{ end }}]
+          </div>
+          {{ end }}
+          </div>
+          <h5 class="is-size-4">Lab Leads</h5>
+          <div class="sidebar-list">
+          {{ range .Params.leads }}
+          <a href="{{ .url }}">{{ .name }}</a>
+          {{ end}}
+          </div>
+          <h5 class="is-size-4">Links</h5>
+          <div class="sidebar-list">
+          {{ range .Params.links }}
+            <a href="{{ .url }}">{{ .name }}</a>
+          {{ end}}
+          </div>
+        </div>
+      </div>
+      <div class="projects columns is-multiline">
+        <div class="column is-12">
+          <h3 class="title is-3">Projekte</h3>
+        </div>
+          {{ range where .Site.Pages ".Params.lab" .File.BaseFileName }}
+          <div class="preview column is-6">
+            <a href="{{.Permalink}}">
+              {{ if isset .Params "imgname" }}
+              <div class="preview-img" style="background-image: url('/projects/{{ .Params.imgname }}');" alt="Project Image"></div>
+              {{ else }}
+              <div class="preview-img" alt="Project Image"></div>
+              {{ end }}
+            </a>
+
+            <span class="date">{{.Date.Format "02.01.2006"}}</span>
+            <a href="{{.Permalink}}"><h3>{{.Title}}</h3></a>
+            {{ if isset .Params "subtitle" }}
+            <h4>{{.Params.Subtitle}}</h4>
+            {{ end }}
+            <p>{{.Params.Excerpt}}</p>
+            <p>{{.Content | truncate 200 }}</p>
+            <span class="lab">{{ with .Site.GetPage (printf "/labs/%s.md" .Params.lab ) }}{{ .Title }}{{ end }}</span>
+            <span class="status">{{.Params.status}}</span>
+          </div>
+          {{ end}}
+      </div>
+    </div>
+  </section>
+{{ end }}

--- a/layouts/labs/single.html
+++ b/layouts/labs/single.html
@@ -51,27 +51,33 @@
         <div class="column is-12">
           <h3 class="title is-3">Projekte</h3>
         </div>
-          {{ range where .Site.Pages ".Params.lab" .File.BaseFileName }}
-          <div class="preview column is-6">
-            <a href="{{.Permalink}}">
-              {{ if isset .Params "imgname" }}
-              <div class="preview-img" style="background-image: url('/projects/{{ .Params.imgname }}');" alt="Project Image"></div>
-              {{ else }}
-              <div class="preview-img" alt="Project Image"></div>
-              {{ end }}
-            </a>
-
-            <span class="date">{{.Date.Format "02.01.2006"}}</span>
-            <a href="{{.Permalink}}"><h3>{{.Title}}</h3></a>
-            {{ if isset .Params "subtitle" }}
-            <h4>{{.Params.Subtitle}}</h4>
+        {{ $fn := .File.BaseFileName }}
+        {{ range .Site.Pages }}
+        {{ if $fn | in .Params.lab }}
+        <div class="preview column is-6">
+          <a href="{{.Permalink}}">
+            {{ if isset .Params "imgname" }}
+            <div class="preview-img" style="background-image: url('/projects/{{ .Params.imgname }}');" alt="Project Image"></div>
+            {{ else }}
+            <div class="preview-img" alt="Project Image"></div>
             {{ end }}
-            <p>{{.Params.Excerpt}}</p>
-            <p>{{.Content | truncate 200 }}</p>
-            <span class="lab">{{ with .Site.GetPage (printf "/labs/%s.md" .Params.lab ) }}{{ .Title }}{{ end }}</span>
-            <span class="status">{{.Params.status}}</span>
-          </div>
-          {{ end}}
+          </a>
+          <span class="date">{{.Date.Format "02.01.2006"}}</span>
+          <a href="{{.Permalink}}"><h3>{{.Title}}</h3></a>
+          {{ if isset .Params "subtitle" }}
+          <h4>{{.Params.Subtitle}}</h4>
+          {{ end }}
+          <p>{{.Params.Excerpt}}</p>
+          <p>{{.Content | truncate 200 }}</p>
+          <span class="lab">
+          {{ range .Params.lab }}
+          {{ with $.Site.GetPage (printf "/labs/%s.md" . ) }}<a href="{{ .Permalink }}">{{ .Title }}</a>{{ end }}
+          {{ end }}
+          </span>
+          <span class="status">{{.Params.status}}</span>
+        </div>
+        {{ end}}
+        {{ end}}
       </div>
     </div>
   </section>

--- a/layouts/projekte/list.html
+++ b/layouts/projekte/list.html
@@ -26,7 +26,11 @@
           {{ end }}
           <p>{{.Params.Excerpt}}</p>
           <p>{{.Content | truncate 200 }}</p>
-          <span class="lab">{{.Params.lab }}</span>
+          <span class="lab">
+          {{ range .Params.lab }}
+          {{ with $.Site.GetPage (printf "/labs/%s.md" . ) }}<a href="{{ .Permalink }}">{{ .Title }}</a>{{ end }}
+          {{ end }}
+          </span>
           <span class="status">{{.Params.status}}</span>
         </div>
         {{ end }}

--- a/layouts/projekte/single.html
+++ b/layouts/projekte/single.html
@@ -28,9 +28,10 @@
           <a href="{{ .url }}">{{ .name }}</a>
         {{ end }}
         <hr>
-        <h3>OK Lab</h3>
-        {{.Params.lab }}
-        {{/* TODO: link to lab */}}
+        <h3>Stadt</h3>
+          {{ range .Params.lab }}
+          {{ with $.Site.GetPage (printf "/labs/%s.md" . ) }}<a href="{{ .Permalink }}">{{ .Title }}</a>{{ end }}
+          {{ end }}
         <hr>
         <h3>Projektstatus</h3>
         {{.Params.status }}

--- a/themes/hugo-cfg/assets/fresh/partials/_lists.scss
+++ b/themes/hugo-cfg/assets/fresh/partials/_lists.scss
@@ -73,3 +73,9 @@ ul li.preview, .preview {
     color: $cfg-cyan-3;
   }
 }
+
+.labs-list .lab-tag {
+  margin: 0.25em;
+  background-color: $cfg-cyan-2;
+  color: black;
+}


### PR DESCRIPTION
Issue #4 

- Fügt eine Labs-Detailseite hinzu
  - Enthält Projekte
- Ein Haufen Änderungen an den Lab und Projekt yaml keys, damit:
  - die Projekte auf den Lab Seiten angezeigt werden können
  - Die Labs mit ihrem auf ihrer Lab Seite konfigurierten Namen auf der Projektseite (und Liste) auftauchen

Noch mehr was mir gerade nicht mehr einfällt
