### PR TITLE
Fix logo color which accidentally got reverted

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -52,7 +52,7 @@ params:
     button: false
 
   footer:
-    logo: /img/CFG_logo.svg
+    logo: /img/CFG_logo_white.svg
     # Social Media Title
     socialmediatitle: Folge uns!
     # Social media links (GitHub, Twitter, etc.). All are optional.


### PR DESCRIPTION
The CFG logo in the footer accidentally got switched back to black instead of white.