### PR TITLE
Add redirects for `/en`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1514,3 +1514,7 @@ to = "/projekte/karlsruhe-drl-welcome"
 [[ redirects ]]
 from = "/projekte/2016-08-15-karlsruhe-drl-schauhin.html"
 to = "/projekte/karlsruhe-drl-schauhin"
+
+[[ redirects ]]
+from = "/en/*"
+to = "/:splat"


### PR DESCRIPTION
There no longer is an English version of the website
so we redirect to the German version of the articles now