### PR TITLE
add redirect for Handbuch Krisenresilienz

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1518,3 +1518,7 @@ to = "/projekte/karlsruhe-drl-schauhin"
 [[ redirects ]]
 from = "/en/*"
 to = "/:splat"
+
+[[ redirects ]]
+from = "/assets/presse/20200409-CFG-Handbuch-Krisenresilienz.pdf"
+to = "/documents/Handbuch-Krisenresilienz.pdf"


### PR DESCRIPTION
Löst (einen Teil von) #129.