### PR TITLE
Lab aliases für /<stadt>

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@ baseURL: https://dev.codefor.de
 languageCode: de-DE
 title: Code for Germany
 theme: codefor-theme
+defaultContentLanguage: de
 
 
 frontmatter:

--- a/content/labs/Beispiel.md
+++ b/content/labs/Beispiel.md
@@ -18,7 +18,7 @@ links:
 - name: Webseite
   url: https://code-for-beispiel.de
   top: true # true | false
-  
+
 - name: GetTogether
   url: https://gettogether.community/code-for-beispiel/
   top: true # true | false
@@ -36,8 +36,11 @@ leads:
   url: lena@codeforbeispiel.de
 - name: Ludwig Lead
   url: ludwig@codeforbeispiel.de
-  
-hero: Hier kommt ein kurzer Teaser Text hin.  
+
+hero: Hier kommt ein kurzer Teaser Text hin.
+
+aliases:
+- /beispiel
 ---)
 
 Hier kommt ein schöner Übersichtstext für Interessierte hin. Was macht euch aus, welche Themen bearbeitet ihr, wie seid ihr in der Stadt verankert etc., Wann, wo und wie trefft ihr euch

--- a/content/labs/berlin.md
+++ b/content/labs/berlin.md
@@ -6,6 +6,9 @@ lat: 52.498493
 long: 13.381215
 markerposition: right
 
+aliases:
+- /berlin
+
 members:
 
 - name: Julia Kloiber

--- a/content/labs/bielefeld.md
+++ b/content/labs/bielefeld.md
@@ -6,6 +6,9 @@ lat: 52.021088
 long: 8.532800
 markerposition: right
 
+aliases:
+- /bielefeld
+
 members:
 
 - name: Helen Bielawa
@@ -49,7 +52,7 @@ leads:
 
 
 calendar:
-- title: Kickoff 
+- title: Kickoff
   date: 25.06.2020
   location: Remote
   url: https://www.meetup.com/de-DE/Code-For-Bielefeld/events/270255036/
@@ -58,10 +61,9 @@ calendar:
 
 Willkommen bei Code for Bielefeld!
 
-Wir sind eine Gruppe von Menschen mit Interessen und Fähigkeiten in den Bereichen Hardware-/Software-Entwicklung, Design und Open Data. 
+Wir sind eine Gruppe von Menschen mit Interessen und Fähigkeiten in den Bereichen Hardware-/Software-Entwicklung, Design und Open Data.
 Gemeinsam wollen wir digitale Werkzeuge und Visualisierungen erstellen, um öffentliche Daten für Bürger*innen sichtbar und nutzbar zu machen.
 
-Jede*r Interessierte ist herzlich eingeladen vorbeizuschauen und mitzumachen! 
+Jede*r Interessierte ist herzlich eingeladen vorbeizuschauen und mitzumachen!
 
 Werde Mitglied in unserer MeetUp-Gruppe, um über Veranstaltungen und Treffen auf dem Laufenden gehalten zu werden.
-

--- a/content/labs/bonn.md
+++ b/content/labs/bonn.md
@@ -5,6 +5,9 @@ lat: 50.7371974
 long: 7.0947157
 markerposition: right
 
+aliases:
+- /bonn
+
 members:
 
 - name: Sven Hense

--- a/content/labs/chemnitz.md
+++ b/content/labs/chemnitz.md
@@ -5,6 +5,9 @@ lat: 50.83063
 long: 12.93973
 markerposition: right
 
+aliases:
+- /chemnitz
+
 members:
 
 - name: Morris Jobke

--- a/content/labs/cottbus.md
+++ b/content/labs/cottbus.md
@@ -6,6 +6,9 @@ long: 14.32216
 markerposition: left # left | right
 showsignup: true # true | false
 
+aliases:
+- /cottbus
+
 members:
 - name: "Benji"
   username_github: fortrieb
@@ -15,18 +18,18 @@ links:
 - name: Webseite
   url: https://okcb.de
   top: true # true | false
-  
+
 leads:
 - name: E-Mail
   url: mailto:hi@okcb.de
-  
+
 ---
 
 Willkommen bei Code for Cottbus!
 
-Einem OK Lab für den besseren Zugang zu Informationen. 
-Wir, das OK Lab Cottbus, sind junge Leute, die in OpenData Projekten freie 
-Daten aufarbeiten, analysieren und visualisieren, um sie in Form von 
+Einem OK Lab für den besseren Zugang zu Informationen.
+Wir, das OK Lab Cottbus, sind junge Leute, die in OpenData Projekten freie
+Daten aufarbeiten, analysieren und visualisieren, um sie in Form von
 digitalen Anwendungen der Gesellschaft frei zur Verfügung zu stellen.
 
 Wir treffen uns Dienstags um 18.30 Uhr in den Räumen des [FabLab Cottbus](https://fablab-cottbus.de).

--- a/content/labs/dresden.md
+++ b/content/labs/dresden.md
@@ -4,6 +4,9 @@ title: Open Data Dresden
 lat: 51.08113
 long: 13.72858
 
+aliases:
+- /dresden
+
 members:
 
 - name: Astro

--- a/content/labs/duesseldorf.md
+++ b/content/labs/duesseldorf.md
@@ -6,6 +6,9 @@ long: 6.7784333
 markerposition: left
 showsignup: false
 
+aliases:
+- /duesseldorf
+
 links:
 - name: Blog
   url: https://codefordus.nrw

--- a/content/labs/erlangen.md
+++ b/content/labs/erlangen.md
@@ -6,6 +6,9 @@ markerposition: right
 showsignup: true
 members: []
 
+aliases:
+- /erlangen
+
 ---
 
 Wir sind eine Gruppe von ehrenamtlich Aktiven, die sich für Offene Daten, Freie und Offene Software und Open Government interessiert. Unser OK Lab setzt sich lokal für eine Verbesserung der Transparenz von Staat und Verwaltungen ein, stößt Projekte zur Bürgerbeteiligung an und sucht den Austausch mit den Verwaltungen, um gemeinsam Lösungen für die Herausforderungen in unserer Region zu finden. Wir treffen uns regelmäßig, um unsere Projekte weiterzuentwickeln.

--- a/content/labs/frankfurt.md
+++ b/content/labs/frankfurt.md
@@ -5,6 +5,9 @@ lat: 50.1167
 long: 8.6833
 markerposition: right
 
+aliases:
+- /frankfurt
+
 members:
 
 - name: Mischa Zöller

--- a/content/labs/freiburg.md
+++ b/content/labs/freiburg.md
@@ -4,6 +4,9 @@ title: OK Lab Freiburg
 lab: OK Lab Freiburg
 markerposition: right
 
+aliases:
+- /freiburg
+
 members:
 
 - name: Andreas Pawelke

--- a/content/labs/giessen.md
+++ b/content/labs/giessen.md
@@ -5,6 +5,9 @@ lat: 50.587142
 long: 8.690926
 markerposition: left
 
+aliases:
+- giessen
+
 showsignup: false
 
 members:

--- a/content/labs/hamburg.md
+++ b/content/labs/hamburg.md
@@ -4,6 +4,9 @@ title: OK Lab Hamburg
 lat: 53.5476165
 long: 9.9800385
 
+aliases:
+- /hamburg
+
 #special: true #this lab gets spcecial marker (digital refugee lab)
 
 markerposition: right

--- a/content/labs/hannover.md
+++ b/content/labs/hannover.md
@@ -6,6 +6,9 @@ lat: 52.366667
 long: 9.716667
 markerposition: left
 
+aliases:
+- /hannover
+
 members:
 
 #- name: Sven Pfennig

--- a/content/labs/heidelberg.md
+++ b/content/labs/heidelberg.md
@@ -6,6 +6,9 @@ lat: 49.40768
 long: 8.69079
 markerposition: left
 
+aliases:
+- /heidelberg
+
 members:
 - name: Jasper Schmidt
   username_github:

--- a/content/labs/heilbronn.md
+++ b/content/labs/heilbronn.md
@@ -5,6 +5,9 @@ lat: 49.139059
 long: 9.220404
 markerposition: right
 
+aliases:
+- /heilbronn
+
 members:
 - name: Adrian Stabiszewski
   username_github: grundid

--- a/content/labs/jena.md
+++ b/content/labs/jena.md
@@ -5,6 +5,9 @@ lat: 50.9223394
 long: 11.5762312
 markerposition: left
 
+aliases:
+- /jena
+
 members:
 
 - name: Achim

--- a/content/labs/karlsruhe.md
+++ b/content/labs/karlsruhe.md
@@ -6,6 +6,9 @@ long: 8.404370
 markerposition: left
 #h4c: true
 
+aliases:
+- /karlsruhe
+
 #special: true #this lab gets spcecial marker (digital refugee lab)
 
 members: []

--- a/content/labs/koeln.md
+++ b/content/labs/koeln.md
@@ -6,6 +6,9 @@ long: 6.9104529
 markerposition: left
 projectsorder: reverse
 
+aliases:
+- /koeln
+
 members:
 
 - name: Marian Steinbach
@@ -92,4 +95,3 @@ Du bist Softwareentwicklerin oder Designer und hast Lust mit Deinen Fähigkeiten
 Dann bist Du herzlich eingeladen, mitzucoden, mitzulernen und mitzureden. Wir freuen uns auf Dich!
 
 [gettogether]: https://gettogether.community/codeforcologne/
-

--- a/content/labs/leipzig.md
+++ b/content/labs/leipzig.md
@@ -4,6 +4,10 @@ title: OK Lab Leipzig
 lat: 51.3322131
 long: 12.3735576
 markerposition: right
+
+aliases:
+- /leipzig
+
 #h4c: true #this lab was part of hack your city
 
 #special: true #this lab gets spcecial marker (digital refugee lab)

--- a/content/labs/magdeburg.md
+++ b/content/labs/magdeburg.md
@@ -5,6 +5,9 @@ lat: 52.11946
 long: 11.62941
 markerposition: right
 
+aliases:
+- /magdeburg
+
 members:
 
 - name: Jens Winter

--- a/content/labs/mecklenburg-vorpommern.md
+++ b/content/labs/mecklenburg-vorpommern.md
@@ -6,6 +6,9 @@ lat: 53.6007
 long: 11.4433
 markerposition: right
 
+aliases:
+- /mecklenburg-vorpommern
+
 members:
 - name: Michael Milz
   username_github: michamilz

--- a/content/labs/muenchen.md
+++ b/content/labs/muenchen.md
@@ -5,6 +5,9 @@ lat: 48.14356
 long: 11.55792
 markerposition: right
 
+aliases:
+- /muenchen
+
 ## LHM Marsstr. 22
 #lat: 48.14356
 #long: 11.55792

--- a/content/labs/muenster.md
+++ b/content/labs/muenster.md
@@ -4,6 +4,9 @@ city: Münster
 lat: 51.964928
 long: 7.630490
 
+aliases:
+- /muenster
+
 members:
 
 - name: Gerald Pape
@@ -63,7 +66,7 @@ links:
 leads:
 - name: Kontakt
   url: mailto:muenster@codefor.de
-  
+
 ---
 
 Als eines der eher technischen Labs dreht es sich bei uns vor allem eher darum, wie man eine solide und offene Basis für Open Data-Anwendungen aller Art herstellen kann.

--- a/content/labs/niederrhein.md
+++ b/content/labs/niederrhein.md
@@ -7,6 +7,9 @@ long: 6.640815
 markerposition: left
 showsignup: false
 
+aliases:
+- /niederrhein
+
 members:
 - name: Timo Jeske
   username_github: odadev

--- a/content/labs/osnabrueck.md
+++ b/content/labs/osnabrueck.md
@@ -7,6 +7,9 @@ long: 8.0497410
 markerposition: left
 showsignup: false
 
+aliases:
+- /osnabrueck
+
 members:
 - name: Peer Wagner
   username_github: wagnerpeer

--- a/content/labs/paderborn.md
+++ b/content/labs/paderborn.md
@@ -3,6 +3,9 @@ city: Paderborn
 title: CodeforPB
 markerposition: right
 
+aliases:
+- /paderborn
+
 members:
 
 - name: Arndt Heuvel

--- a/content/labs/potsdam.md
+++ b/content/labs/potsdam.md
@@ -6,6 +6,9 @@ lat: 52.38947
 long: 13.07853
 markerposition: left
 
+aliases:
+- /potsdam
+
 members: []
 
 

--- a/content/labs/ruhrgebiet.md
+++ b/content/labs/ruhrgebiet.md
@@ -6,6 +6,9 @@ long: 7.024764
 markerposition: right
 showsignup: false
 
+aliases:
+- /ruhrgebiet
+
 links:
 - name: Mailingliste
   url: https://mlists.okfn.de/cgi-bin/mailman/listinfo/codeforruhrgebiet

--- a/content/labs/schleswig-flensburg.md
+++ b/content/labs/schleswig-flensburg.md
@@ -6,6 +6,9 @@ lat: 54.66414
 long: 9.40062
 markerposition: right
 
+aliases:
+- /schleswig-flensburg
+
 members:
 
 - name: Frank Radzio

--- a/content/labs/stuttgart.md
+++ b/content/labs/stuttgart.md
@@ -5,6 +5,9 @@ lat: 48.776540
 long: 9.173700
 markerposition: right
 
+aliases:
+- /stuttgart
+
 members:
 - name: Jan Lutz
   username_twitter: Jan_sagt
@@ -59,7 +62,7 @@ leads:
   url: mailto:rajko@codefor.de
   username_twitter: ricki_z
   username_github: ricki-z
-  
+
   hero: Home of sensor.community
 
 ---

--- a/content/labs/ulm.md
+++ b/content/labs/ulm.md
@@ -6,6 +6,8 @@ lat: 48.39645
 long: 9.99042
 markerposition: left
 
+aliases:
+- /ulm
 
 members:
 

--- a/content/labs/wuppertal.md
+++ b/content/labs/wuppertal.md
@@ -7,6 +7,9 @@ long: 7.14539
 markerposition: right
 h4c: true
 
+aliases:
+- /wuppertal
+
 members:
 
 - name: Nico Heßler


### PR DESCRIPTION
Dieser PR fügt für alle lab seiten einen hugo alias für /<stadt> hinzu. Der Unterschied zwischen den netlify redirects und hugo redirects ist, dass hugo extra html seiten anlegt mit einem redirect, die dann so aussehen:

```html
<!DOCTYPE html>
<html>
   <head>
      <title>https://dev.codefor.de/labs/muenster/</title>
      <link rel="canonical" href="https://dev.codefor.de/labs/muenster/"/>
      <meta name="robots" content="noindex">
      <meta charset="utf-8" />
      <meta http-equiv="refresh" content="0; url=https://dev.codefor.de/labs/muenster/" />
   </head>
</html>

```